### PR TITLE
Remote backup destinations + mark non-library movies watched

### DIFF
--- a/docs/watch-history-backups.md
+++ b/docs/watch-history-backups.md
@@ -114,5 +114,16 @@ before OAuth, remote retention, and provider failure modes are introduced.
 
 Stage 1 is implemented with a dedicated **Settings -> Backups** page, local gzip
 files, daily scheduling, retention, authenticated downloads, checksum validation,
-and dry-run, merge, or replace restores. Remote destination adapters remain the
-next stage.
+and dry-run, merge, or replace restores.
+
+Remote destination adapters are now implemented under
+`server/src/utils/backupDestinations/` (WebDAV, S3-compatible, OneDrive, Dropbox),
+all sharing the `testConnection / upload / list / delete` contract. The local backup
+is always written and verified first; each enabled remote is then mirrored
+best-effort, with per-destination status recorded in the backup runtime and remote
+retention ordered by the sortable backup filename. A remote failure never
+invalidates or deletes the local backup. Credentials live server-side in the
+`watchBackupDestinations` settings row and are redacted to "is-set" flags in every
+API response. OneDrive uses the Microsoft device-code flow (user supplies an Azure
+app client ID); Dropbox uses the manual no-redirect OAuth code flow; both store a
+refresh token. Optional AES-256-GCM encryption (stage 5) is still pending.

--- a/public/app.js
+++ b/public/app.js
@@ -207,6 +207,9 @@ function bindElements() {
     refreshWatchBackupsButton: document.querySelector("#refreshWatchBackupsButton"),
     watchBackupRuntime: document.querySelector("#watchBackupRuntime"),
     watchBackupList: document.querySelector("#watchBackupList"),
+    watchBackupDestinations: document.querySelector("#watchBackupDestinations"),
+    watchBackupDestinationType: document.querySelector("#watchBackupDestinationType"),
+    addWatchBackupDestinationButton: document.querySelector("#addWatchBackupDestinationButton"),
     helpCanvas: document.querySelector("#helpCanvas"),
     helpMenu: document.querySelector("#helpMenu"),
     tvHistoryRow: document.querySelector("#tvHistoryRow"),
@@ -562,6 +565,233 @@ function renderWatchBackups() {
       </div>
     </article>
   `).join("") : `<div class="empty-log"><b>No watch-history backups yet</b><span>Use Back Up Now or enable the daily schedule.</span></div>`;
+
+  renderWatchBackupDestinations(data);
+}
+
+const DESTINATION_FORMS = {
+  webdav: {
+    label: "WebDAV",
+    settings: [
+      { key: "url", label: "Collection URL", placeholder: "https://cloud.example.com/remote.php/dav/files/me/plembfin/" },
+      { key: "username", label: "Username", placeholder: "username" },
+    ],
+    secrets: [{ key: "password", label: "Password" }],
+    oauth: null,
+  },
+  s3: {
+    label: "S3-compatible",
+    settings: [
+      { key: "endpoint", label: "Endpoint (blank for AWS)", placeholder: "http://localhost:9000" },
+      { key: "region", label: "Region", placeholder: "us-east-1" },
+      { key: "bucket", label: "Bucket", placeholder: "my-backups" },
+      { key: "prefix", label: "Key prefix (optional)", placeholder: "plembfin/" },
+      { key: "accessKeyId", label: "Access key ID", placeholder: "AKIA…" },
+      { key: "forcePathStyle", label: "Use path-style URLs (MinIO, B2, most non-AWS)", type: "checkbox", default: true },
+    ],
+    secrets: [{ key: "secretAccessKey", label: "Secret access key" }],
+    oauth: null,
+  },
+  onedrive: {
+    label: "OneDrive",
+    settings: [
+      { key: "clientId", label: "Azure app client ID", placeholder: "00000000-0000-0000-0000-000000000000" },
+      { key: "tenant", label: "Tenant (common / consumers / tenant ID)", placeholder: "common" },
+    ],
+    secrets: [],
+    oauth: "device",
+  },
+  dropbox: {
+    label: "Dropbox",
+    settings: [
+      { key: "appKey", label: "App key", placeholder: "abcd1234efgh5678" },
+      { key: "folder", label: "Folder", placeholder: "/Plembfin Backups" },
+    ],
+    secrets: [{ key: "appSecret", label: "App secret" }],
+    oauth: "code",
+  },
+};
+
+function destinationStatusPill(destination, status) {
+  const connected = !destination.secretFlags || destination.secretFlags.refreshToken;
+  const needsOauth = DESTINATION_FORMS[destination.type]?.oauth;
+  if (needsOauth && !destination.secretFlags?.refreshToken) {
+    return `<span class="status-pill status-warning">Not connected</span>`;
+  }
+  if (status?.status === "success") {
+    return `<span class="status-pill status-ready">Synced ${escapeHtml(watchBackupDate(status.lastSuccessAt))}</span>`;
+  }
+  if (status?.status === "error") {
+    return `<span class="status-pill status-danger">Last run failed</span>`;
+  }
+  return `<span class="status-pill status-muted">${connected ? "Not run yet" : "Not connected"}</span>`;
+}
+
+function renderDestinationField(destination, field) {
+  const value = destination.settings?.[field.key];
+  if (field.type === "checkbox") {
+    const checked = value === undefined ? field.default : Boolean(value);
+    return `<label class="checkbox-label"><input type="checkbox" data-dest-setting="${field.key}" ${checked ? "checked" : ""} /><span>${escapeHtml(field.label)}</span></label>`;
+  }
+  return `<label class="field-label">${escapeHtml(field.label)}
+    <input class="field" data-dest-setting="${field.key}" value="${escapeAttribute(value || "")}" placeholder="${escapeAttribute(field.placeholder || "")}" />
+  </label>`;
+}
+
+function renderDestinationSecret(destination, field) {
+  const isSet = destination.secretFlags?.[field.key];
+  return `<label class="field-label">${escapeHtml(field.label)}
+    <input class="field" type="password" autocomplete="new-password" data-dest-secret="${field.key}" placeholder="${isSet ? "•••••••• (saved — leave blank to keep)" : ""}" />
+  </label>`;
+}
+
+function renderWatchBackupDestinations(data) {
+  const host = elements.watchBackupDestinations;
+  if (!host) return;
+  if (!data) {
+    host.innerHTML = `<div class="empty-log"><b>Destinations not loaded</b></div>`;
+    return;
+  }
+  const destinations = Array.isArray(data.destinations) ? data.destinations : [];
+  const statusMap = data.runtime?.destinations || {};
+  if (!destinations.length) {
+    host.innerHTML = `<div class="empty-log"><b>No remote destinations</b><span>Pick a type above and choose Add destination to mirror backups off-box.</span></div>`;
+    return;
+  }
+  host.innerHTML = destinations.map((destination) => {
+    const form = DESTINATION_FORMS[destination.type] || { label: destination.type, settings: [], secrets: [], oauth: null };
+    const fields = form.settings.map((field) => renderDestinationField(destination, field)).join("");
+    const secrets = form.secrets.map((field) => renderDestinationSecret(destination, field)).join("");
+    const connected = destination.secretFlags?.refreshToken;
+    const status = statusMap[destination.id];
+    return `
+      <article class="watch-backup-destination" data-dest-id="${escapeAttribute(destination.id)}" data-dest-type="${escapeAttribute(destination.type)}">
+        <div class="destination-head">
+          <span class="destination-badge">${escapeHtml(form.label)}</span>
+          <input class="field destination-label" data-dest-meta="label" value="${escapeAttribute(destination.label || form.label)}" />
+          <label class="checkbox-label"><input type="checkbox" data-dest-meta="enabled" ${destination.enabled ? "checked" : ""} /><span>Enabled</span></label>
+          ${destinationStatusPill(destination, status)}
+        </div>
+        <div class="destination-fields">
+          ${fields}
+          ${secrets}
+        </div>
+        <div class="destination-feedback" data-dest-feedback>${status?.status === "error" && status.lastError ? escapeHtml(status.lastError) : ""}</div>
+        <div class="destination-actions">
+          <button class="button-primary" type="button" data-dest-action="save">Save</button>
+          <button class="button-ghost" type="button" data-dest-action="test">Test</button>
+          ${form.oauth ? `<button class="button-ghost" type="button" data-dest-action="connect">${connected ? "Reconnect" : "Connect"}</button>` : ""}
+          <button class="button-danger" type="button" data-dest-action="remove">Remove</button>
+        </div>
+      </article>
+    `;
+  }).join("");
+}
+
+function collectDestination(card) {
+  const settings = {};
+  card.querySelectorAll("[data-dest-setting]").forEach((input) => {
+    settings[input.dataset.destSetting] = input.type === "checkbox" ? input.checked : input.value.trim();
+  });
+  const secrets = {};
+  card.querySelectorAll("[data-dest-secret]").forEach((input) => {
+    if (input.value) secrets[input.dataset.destSecret] = input.value;
+  });
+  return {
+    id: card.dataset.destId,
+    type: card.dataset.destType,
+    label: card.querySelector('[data-dest-meta="label"]')?.value?.trim() || card.dataset.destType,
+    enabled: Boolean(card.querySelector('[data-dest-meta="enabled"]')?.checked),
+    settings,
+    secrets,
+  };
+}
+
+async function addBackupDestination() {
+  const type = elements.watchBackupDestinationType?.value || "webdav";
+  const label = DESTINATION_FORMS[type]?.label || type;
+  await postWatchBackupAction({ action: "save-destination", destination: { type, label, enabled: false, settings: {}, secrets: {} } });
+  state.watchBackups = null;
+  await loadWatchBackups({ force: true });
+  setMessage(`Added ${label} destination — fill in the details and Save.`, "success");
+}
+
+async function saveBackupDestinationCard(card) {
+  await postWatchBackupAction({ action: "save-destination", destination: collectDestination(card) });
+  state.watchBackups = null;
+  await loadWatchBackups({ force: true });
+  setMessage("Destination saved.", "success");
+}
+
+async function testBackupDestinationCard(card) {
+  const destination = collectDestination(card);
+  // Persist first so the server tests exactly what is shown.
+  await postWatchBackupAction({ action: "save-destination", destination });
+  const result = await postWatchBackupAction({ action: "test-destination", destinationId: destination.id });
+  setMessage(`Connection OK — ${result.result?.detail || "reachable"}.`, "success");
+  state.watchBackups = null;
+  await loadWatchBackups({ force: true });
+}
+
+async function removeBackupDestinationCard(card) {
+  const approved = await openConfirmDialog({
+    title: "Remove destination?",
+    body: "Stop mirroring backups here? Files already uploaded to the remote are left untouched.",
+    confirmLabel: "Remove",
+    danger: true,
+  });
+  if (!approved) return;
+  await postWatchBackupAction({ action: "remove-destination", destinationId: card.dataset.destId });
+  state.watchBackups = null;
+  await loadWatchBackups({ force: true });
+  setMessage("Destination removed.", "success");
+}
+
+async function connectBackupDestinationCard(card) {
+  const destination = collectDestination(card);
+  // Persist client/app credentials before kicking off the OAuth handshake.
+  await postWatchBackupAction({ action: "save-destination", destination });
+  if (destination.type === "onedrive") return connectOneDriveDestination(destination.id, card);
+  if (destination.type === "dropbox") return connectDropboxDestination(destination.id, card);
+}
+
+async function connectOneDriveDestination(id, card) {
+  const feedback = card.querySelector("[data-dest-feedback]");
+  const start = await postWatchBackupAction({ action: "device-start", destinationId: id });
+  if (feedback) {
+    feedback.innerHTML = `Open <a href="${escapeAttribute(start.verificationUri)}" target="_blank" rel="noopener">${escapeHtml(start.verificationUri)}</a> and enter code <b>${escapeHtml(start.userCode)}</b>. Waiting for approval…`;
+  }
+  const deadline = Date.now() + (Number(start.expiresIn) || 900) * 1000;
+  const interval = Math.max(2, Number(start.interval) || 5) * 1000;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, interval));
+    const poll = await postWatchBackupAction({ action: "device-poll", pendingId: start.pendingId });
+    if (poll.status === "authorized") {
+      setMessage("OneDrive connected.", "success");
+      state.watchBackups = null;
+      await loadWatchBackups({ force: true });
+      return;
+    }
+    if (poll.status === "error") {
+      if (feedback) feedback.textContent = poll.error || "Authorization failed.";
+      setMessage(poll.error || "OneDrive authorization failed.", "error");
+      return;
+    }
+  }
+  if (feedback) feedback.textContent = "Login timed out — start again.";
+}
+
+async function connectDropboxDestination(id, card) {
+  const feedback = card.querySelector("[data-dest-feedback]");
+  const { url } = await postWatchBackupAction({ action: "oauth-url", destinationId: id });
+  window.open(url, "_blank", "noopener");
+  if (feedback) feedback.innerHTML = `A Dropbox tab opened. Approve access, then paste the code below.`;
+  const code = window.prompt("Dropbox: after approving access, paste the authorization code here:");
+  if (!code) return;
+  await postWatchBackupAction({ action: "oauth-exchange", destinationId: id, code });
+  setMessage("Dropbox connected.", "success");
+  state.watchBackups = null;
+  await loadWatchBackups({ force: true });
 }
 
 async function loadWatchBackups({ force = false } = {}) {
@@ -5745,9 +5975,50 @@ function showModalStatus(loading, hasTmdbKey, hasTmdbData) {
   return "";
 }
 
+function renderMovieWatchDatePrompt(action, customValue) {
+  const movie = action.movie || {};
+  const releaseLabel = movie.releaseDate ? formatTmdbDate(movie.releaseDate) : "Unknown release date";
+  return `
+    <div class="watch-date-overlay" role="dialog" aria-modal="true" aria-label="Choose watched date">
+      <div class="watch-date-dialog">
+        <div class="watch-date-head">
+          <div class="watch-date-head-text">
+            <h3>${escapeHtml(action.label)}</h3>
+            <p class="watch-date-sub">${escapeHtml(movie.title || "Movie")} &middot; Movie</p>
+          </div>
+          <button class="watch-date-close" type="button" data-watch-date-cancel="true" aria-label="Cancel">&times;</button>
+        </div>
+
+        <p class="watch-date-intro">Logs this movie to your watch history and marks it played on Plex, Emby, and Jellyfin. Pick which date to record.</p>
+
+        <div class="watch-date-section-label">Watched date</div>
+        <div class="watch-date-options">
+          <button class="watch-date-pick" type="button" data-watch-date-choice="release"${movie.releaseDate ? "" : " disabled"}>
+            <span class="watch-date-pick-title">Day of release</span>
+            <span class="watch-date-pick-sub">${escapeHtml(releaseLabel)}</span>
+          </button>
+          <button class="watch-date-pick" type="button" data-watch-date-choice="now">
+            <span class="watch-date-pick-title">Now</span>
+            <span class="watch-date-pick-sub">Today, ${escapeHtml(formatTmdbDate(customValue))}</span>
+          </button>
+        </div>
+
+        <div class="watch-date-custom">
+          <label for="watchDateCustomInput">Or pick a specific date</label>
+          <div class="watch-date-custom-row">
+            <input id="watchDateCustomInput" type="date" value="${escapeAttribute(customValue)}" max="${escapeAttribute(customValue)}" />
+            <button class="button-primary" type="button" data-watch-date-choice="custom">Use date</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
 function renderWatchDatePrompt(action) {
   if (!action) return "";
   const customValue = new Date().toISOString().slice(0, 10);
+  if (action.scope === "movie") return renderMovieWatchDatePrompt(action, customValue);
   const episodeCount = action.episodes.length;
   const them = episodeCount === 1 ? "this episode" : "these episodes";
   const episodesHtml = action.episodes
@@ -6197,6 +6468,61 @@ function watchRecordFromEpisode(episode, watchedAt) {
   };
 }
 
+function watchRecordFromMovie(movie, watchedAt) {
+  return {
+    media_type: "movie",
+    title: movie.title,
+    watched_at: watchedAt,
+    source: "manual",
+    tmdb_id: movie.tmdbId || null,
+    poster_url: movie.posterUrl || null,
+  };
+}
+
+function markMovieWatched(movie) {
+  if (!movie?.title) {
+    setMessage("Cannot mark this movie watched — missing details.", "error");
+    return;
+  }
+  openWatchDatePrompt({
+    scope: "movie",
+    movie,
+    label: `Mark ${movie.title} watched`,
+    showTitle: movie.title,
+    countLabel: "1 movie",
+  });
+}
+
+async function applyMovieWatchDateChoice(choice) {
+  const action = state.pendingWatchAction;
+  const movie = action?.movie;
+  if (!movie) return;
+
+  const root = mediaDetailRoot();
+  const customDate = root.querySelector("#watchDateCustomInput")?.value || "";
+  const watchedAt = watchedAtForChoice(choice, { airDate: movie.releaseDate }, customDate);
+  const record = watchRecordFromMovie(movie, watchedAt);
+
+  root.querySelectorAll("[data-watch-date-choice], [data-watch-date-cancel]").forEach((button) => {
+    button.disabled = true;
+  });
+  closeWatchDatePrompt();
+
+  try {
+    const result = await postManualWatchRecords([record]);
+    clearDerivedUiCaches({ resetExplorer: false });
+    setMessage(
+      `Marked "${movie.title}" watched${result.skipped ? " (already logged)" : ""}; pushed ${result.propagated} to media apps.`,
+      result.rejected ? "error" : "success",
+    );
+    await loadHistory({ force: true }).catch(() => null);
+    if (movie.tmdbId) await openMovieImmersiveModalByTmdbId(movie.tmdbId);
+  } catch (error) {
+    setMessage(`Manual watch update failed: ${error.message}`, "error");
+    throw error;
+  }
+}
+
 function localWatchRowFromEpisode(episode, watchedAt) {
   return {
     id: `local-${episode.key}-${Date.now()}`,
@@ -6295,6 +6621,7 @@ async function refreshShowAfterManualWatch(showTitle) {
 
 async function applyWatchDateChoice(choice) {
   const action = state.pendingWatchAction;
+  if (action?.scope === "movie") return applyMovieWatchDateChoice(choice);
   if (!action?.episodes?.length) return;
 
   const root = mediaDetailRoot();
@@ -6745,6 +7072,13 @@ async function renderMovieImmersiveModalContent(movie) {
 }
 
 async function openMovieImmersiveModalByTmdbId(tmdbId) {
+  // If this movie is already logged locally, show its watched detail (watch date +
+  // unwatch controls) instead of the unwatched TMDB view.
+  const existingWatched = state.history.find(
+    (entry) => entry.media_type === "movie" && isWatchedHistoryAction(entry) && String(entry.tmdb_id || "") === String(tmdbId),
+  );
+  if (existingWatched) return renderMovieImmersiveModalContent(existingWatched);
+
   if (!state.mediaDetailInline) {
     elements.debugModal.classList.remove("hidden");
     document.body.style.overflow = "hidden";
@@ -6819,6 +7153,13 @@ async function openMovieImmersiveModalByTmdbId(tmdbId) {
             </div>
             <div class="progress-bar-track">
               <div class="progress-bar-fill" style="width: 0%;"></div>
+            </div>
+            <div class="immersive-actions" style="margin-top: 0.75rem;">
+              <button class="action-pill" type="button"
+                data-movie-mark-watched="${escapeAttribute(String(tmdbId))}"
+                data-movie-title="${escapeAttribute(movieTitle)}"
+                data-movie-poster="${escapeAttribute(posterUrl)}"
+                data-movie-release="${escapeAttribute(tmdbData.release_date || "")}">Mark watched</button>
             </div>
           </section>
         </div>
@@ -8248,6 +8589,24 @@ function attachEvents() {
     }
   });
 
+  elements.addWatchBackupDestinationButton?.addEventListener("click", () => {
+    addBackupDestination().catch((error) => setMessage(error.message, "error"));
+  });
+  elements.watchBackupDestinations?.addEventListener("click", (event) => {
+    const button = event.target.closest("[data-dest-action]");
+    if (!button) return;
+    const card = button.closest("[data-dest-id]");
+    if (!card) return;
+    const actions = {
+      save: saveBackupDestinationCard,
+      test: testBackupDestinationCard,
+      remove: removeBackupDestinationCard,
+      connect: connectBackupDestinationCard,
+    };
+    const run = actions[button.dataset.destAction];
+    if (run) run(card).catch((error) => setMessage(error.message, "error"));
+  });
+
 
   elements.explorerButtons.forEach((button) => {
     button.addEventListener("click", () => {
@@ -8505,6 +8864,17 @@ function attachEvents() {
     const watchButton = event.target.closest("[data-watch-scope]");
     if (watchButton) {
       openWatchDatePrompt(watchActionFromButton(watchButton));
+      return;
+    }
+
+    const movieWatchButton = event.target.closest("[data-movie-mark-watched]");
+    if (movieWatchButton) {
+      markMovieWatched({
+        tmdbId: movieWatchButton.dataset.movieMarkWatched,
+        title: movieWatchButton.dataset.movieTitle,
+        posterUrl: movieWatchButton.dataset.moviePoster,
+        releaseDate: movieWatchButton.dataset.movieRelease,
+      });
       return;
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -673,15 +673,9 @@
                       Backups to retain
                       <input id="watchBackupRetention" class="field" type="number" min="1" max="365" value="14" />
                     </label>
-                    <label class="field-label">
-                      Destination
-                      <select id="watchBackupDestination" class="field" disabled>
-                        <option value="local">Local data folder</option>
-                      </select>
-                    </label>
                   </div>
 
-                  <p class="tool-accordion-desc">Backups are stored in <code>data/backups/watch-history</code>. Artwork, TMDB caches, credentials, settings, logs, and active sessions are excluded. Dropbox, OneDrive, WebDAV, and S3-compatible destinations will use this same verified local backup format.</p>
+                  <p class="tool-accordion-desc">Backups are always written to <code>data/backups/watch-history</code> first, then mirrored to any enabled remote destinations below. Artwork, TMDB caches, credentials, settings, logs, and active sessions are excluded.</p>
 
                   <div class="settings-actions backup-settings-actions">
                     <button id="saveWatchBackupConfigButton" class="button-primary" type="button">Save Schedule</button>
@@ -690,6 +684,25 @@
                   </div>
 
                   <div id="watchBackupRuntime" class="backup-runtime" aria-live="polite"></div>
+                </section>
+
+                <section class="glass-panel p-section backup-settings-panel">
+                  <div class="section-heading">
+                    <div>
+                      <p>Remote Destinations</p>
+                      <span>Mirror backups to OneDrive, Dropbox, WebDAV, or S3-compatible storage. The local copy is always kept.</span>
+                    </div>
+                    <div class="backup-destination-add">
+                      <select id="watchBackupDestinationType" class="field">
+                        <option value="webdav">WebDAV</option>
+                        <option value="s3">S3-compatible</option>
+                        <option value="onedrive">OneDrive</option>
+                        <option value="dropbox">Dropbox</option>
+                      </select>
+                      <button id="addWatchBackupDestinationButton" class="button-primary" type="button">Add destination</button>
+                    </div>
+                  </div>
+                  <div id="watchBackupDestinations" class="watch-backup-destinations" aria-live="polite"></div>
                 </section>
 
                 <section class="glass-panel p-section backup-settings-panel">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1718,6 +1718,69 @@ details[open] .tool-accordion-chevron::before {
   gap: var(--space-2);
 }
 
+.backup-destination-add {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.watch-backup-destinations {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.watch-backup-destination {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-3);
+}
+
+.destination-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.destination-badge {
+  font-weight: 600;
+  font-size: 0.8rem;
+  padding: 0.15rem 0.55rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel-2);
+}
+
+.destination-label {
+  flex: 1 1 160px;
+  min-width: 120px;
+}
+
+.destination-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2) var(--space-3);
+}
+
+.destination-feedback {
+  color: var(--muted);
+  font-size: 0.82rem;
+  min-height: 1rem;
+}
+
+.destination-feedback:empty {
+  display: none;
+}
+
+.destination-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
 @media (max-width: 860px) {
   .backup-settings-grid,
   .backup-runtime {
@@ -1731,6 +1794,10 @@ details[open] .tool-accordion-chevron::before {
 
   .watch-backup-actions {
     justify-content: flex-start;
+  }
+
+  .destination-fields {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { normalizeProviderIds, parseCustomWebhook, parseEmbyWebhook, parseJellyfinWebhook, parsePlexWebhook } from "./utils/parsers.js";
 import { findPlexItem, markPlexPlayed, setPlexProgress } from "./utils/plexClient.js";
 import { markEmbyPlayed, setEmbyProgress } from "./utils/embyClient.js";
@@ -66,12 +67,18 @@ import { getTmdbDetails, getTmdbImages, getTmdbPerson, getTmdbSeason, prewarmTmd
 import { BACKUP_FORMAT, BACKUP_VERSION, backupManifest, exportCollectionPage, importCollectionBatch } from "./utils/backup.js";
 import {
   createWatchHistoryBackup,
+  getBackupDestination,
   readWatchBackupFile,
+  removeBackupDestination,
   restoreWatchHistoryBackup,
   runScheduledWatchBackup,
   saveWatchBackupConfig,
+  saveBackupDestination,
+  testBackupDestination,
+  updateDestinationSecrets,
   watchBackupStatus,
 } from "./utils/watchHistoryBackups.js";
+import { deviceCodeEndpoint, tokenEndpoint, ONEDRIVE_SCOPE } from "./utils/backupDestinations/onedrive.js";
 
 function routePath(req) {
   const path = req.path || new URL(req.originalUrl || req.url, "https://local").pathname;
@@ -515,6 +522,102 @@ async function handleBackupImport(req, res) {
   }
 }
 
+// In-memory pending OneDrive device-code sessions (pendingId -> session). Short-lived
+// and intentionally not persisted; a server restart simply cancels an in-flight login.
+const deviceCodeSessions = new Map();
+
+async function startOneDriveDeviceAuth(destination) {
+  const clientId = destination.settings?.clientId;
+  if (!clientId) throw new Error("Enter and save the OneDrive client ID first");
+  const tenant = destination.settings?.tenant;
+  const params = new URLSearchParams({ client_id: clientId, scope: ONEDRIVE_SCOPE });
+  const response = await fetch(deviceCodeEndpoint(tenant), {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(data.error_description || data.error || `Device code request failed (${response.status})`);
+
+  const pendingId = crypto.randomUUID();
+  deviceCodeSessions.set(pendingId, {
+    destinationId: destination.id,
+    clientId,
+    tenant,
+    deviceCode: data.device_code,
+    expiresAt: Date.now() + (Number(data.expires_in) || 900) * 1000,
+  });
+  return {
+    pendingId,
+    userCode: data.user_code,
+    verificationUri: data.verification_uri,
+    interval: Number(data.interval) || 5,
+    expiresIn: Number(data.expires_in) || 900,
+    message: data.message,
+  };
+}
+
+async function pollOneDriveDeviceAuth(pendingId) {
+  const session = deviceCodeSessions.get(pendingId);
+  if (!session) return { status: "error", error: "Login session expired — start again" };
+  if (session.expiresAt < Date.now()) {
+    deviceCodeSessions.delete(pendingId);
+    return { status: "error", error: "Login code expired — start again" };
+  }
+  const params = new URLSearchParams({
+    client_id: session.clientId,
+    grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    device_code: session.deviceCode,
+  });
+  const response = await fetch(tokenEndpoint(session.tenant), {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (response.ok && data.refresh_token) {
+    updateDestinationSecrets(session.destinationId, { refreshToken: data.refresh_token });
+    deviceCodeSessions.delete(pendingId);
+    return { status: "authorized" };
+  }
+  if (data.error === "authorization_pending" || data.error === "slow_down") return { status: "pending" };
+  deviceCodeSessions.delete(pendingId);
+  return { status: "error", error: data.error_description || data.error || "Authorization failed" };
+}
+
+// Dropbox manual (no-redirect) OAuth: the authorize page shows a code the user pastes
+// back, so no public callback URL is required for self-hosted installs.
+function dropboxAuthorizeUrl(destination) {
+  const appKey = destination.settings?.appKey;
+  if (!appKey) throw new Error("Enter and save the Dropbox app key first");
+  const params = new URLSearchParams({
+    client_id: appKey,
+    response_type: "code",
+    token_access_type: "offline",
+  });
+  return `https://www.dropbox.com/oauth2/authorize?${params.toString()}`;
+}
+
+async function exchangeDropboxCode(destination, code) {
+  const appKey = destination.settings?.appKey;
+  const appSecret = destination.secrets?.appSecret;
+  if (!appKey || !appSecret) throw new Error("Save the Dropbox app key and secret first");
+  if (!code) throw new Error("Authorization code is required");
+  const basic = Buffer.from(`${appKey}:${appSecret}`).toString("base64");
+  const params = new URLSearchParams({ grant_type: "authorization_code", code: String(code).trim() });
+  const response = await fetch("https://api.dropbox.com/oauth2/token", {
+    method: "POST",
+    headers: { Authorization: `Basic ${basic}`, "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok || !data.refresh_token) {
+    throw new Error(data.error_description || data.error || "Dropbox authorization failed");
+  }
+  updateDestinationSecrets(destination.id, { refreshToken: data.refresh_token });
+  return { status: "authorized" };
+}
+
 async function handleWatchBackups(req, res) {
   if (req.method === "OPTIONS") return sendOptions(res);
   if (!(await requireAdmin(req, res))) return;
@@ -543,7 +646,7 @@ async function handleWatchBackups(req, res) {
       return sendJson(res, { ok: true, config: saveWatchBackupConfig(body.config || {}) });
     }
     if (action === "create") {
-      return sendJson(res, { ok: true, backup: createWatchHistoryBackup({ reason: "manual" }) });
+      return sendJson(res, { ok: true, backup: await createWatchHistoryBackup({ reason: "manual" }) });
     }
     if (action === "restore") {
       const filename = String(body.filename || "").trim();
@@ -555,6 +658,33 @@ async function handleWatchBackups(req, res) {
           dryRun: body.dryRun === true,
         }),
       });
+    }
+    if (action === "save-destination") {
+      return sendJson(res, { ok: true, destination: saveBackupDestination(body.destination || {}) });
+    }
+    if (action === "remove-destination") {
+      const id = String(body.destinationId || "").trim();
+      if (!id) return sendJson(res, { error: "destinationId is required" }, 400);
+      return sendJson(res, { ok: true, ...removeBackupDestination(id) });
+    }
+    if (["test-destination", "device-start", "device-poll", "oauth-url", "oauth-exchange"].includes(action)) {
+      if (action === "device-poll") {
+        return sendJson(res, { ok: true, ...(await pollOneDriveDeviceAuth(String(body.pendingId || ""))) });
+      }
+      const destination = getBackupDestination(String(body.destinationId || "").trim());
+      if (!destination) return sendJson(res, { error: "Destination not found" }, 404);
+      if (action === "test-destination") {
+        return sendJson(res, { ok: true, result: await testBackupDestination(destination) });
+      }
+      if (action === "device-start") {
+        return sendJson(res, { ok: true, ...(await startOneDriveDeviceAuth(destination)) });
+      }
+      if (action === "oauth-url") {
+        return sendJson(res, { ok: true, url: dropboxAuthorizeUrl(destination) });
+      }
+      if (action === "oauth-exchange") {
+        return sendJson(res, { ok: true, ...(await exchangeDropboxCode(destination, body.code)) });
+      }
     }
     return sendJson(res, { error: "Unknown watch backup action" }, 400);
   } catch (error) {

--- a/server/src/utils/backupDestinations/dropbox.js
+++ b/server/src/utils/backupDestinations/dropbox.js
@@ -1,0 +1,113 @@
+// Dropbox adapter (API v2). Auth is the OAuth refresh-token flow handled in the API
+// layer; this adapter refreshes the access token and reads/writes an app-scoped
+// folder. Settings: { appKey, folder? }  Secrets: { appSecret, refreshToken }
+import fs from "node:fs";
+
+const FILE_PATTERN = /^plembfin-watch-history-\d{8}T\d{6}Z\.json\.gz$/;
+
+// access_token cache keyed by destination id (refresh tokens live in the DB).
+const tokenCache = new Map();
+
+function folderPath(destination) {
+  let folder = String(destination.settings?.folder || "/Plembfin Backups").trim();
+  if (!folder.startsWith("/")) folder = `/${folder}`;
+  return folder.replace(/\/+$/, "");
+}
+
+async function ensureAccessToken(destination) {
+  const cached = tokenCache.get(destination.id);
+  if (cached && cached.expiresAt > Date.now() + 60000) return cached.accessToken;
+
+  const appKey = destination.settings?.appKey;
+  const appSecret = destination.secrets?.appSecret;
+  const refreshToken = destination.secrets?.refreshToken;
+  if (!appKey || !appSecret) throw new Error("Dropbox app key and secret are required");
+  if (!refreshToken) throw new Error("Dropbox is not connected — run Connect first");
+
+  const basic = Buffer.from(`${appKey}:${appSecret}`).toString("base64");
+  const params = new URLSearchParams({ grant_type: "refresh_token", refresh_token: refreshToken });
+  const response = await fetch("https://api.dropbox.com/oauth2/token", {
+    method: "POST",
+    headers: { Authorization: `Basic ${basic}`, "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(`Dropbox token refresh failed: ${data.error_description || data.error || response.status}`);
+  }
+  tokenCache.set(destination.id, {
+    accessToken: data.access_token,
+    expiresAt: Date.now() + (Number(data.expires_in) || 14400) * 1000,
+  });
+  return data.access_token;
+}
+
+export function createDropboxAdapter(destination) {
+  async function bearer() {
+    return `Bearer ${await ensureAccessToken(destination)}`;
+  }
+
+  return {
+    async testConnection() {
+      const response = await fetch("https://api.dropboxapi.com/2/users/get_current_account", {
+        method: "POST",
+        headers: { Authorization: await bearer() },
+      });
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`Dropbox connection failed (${response.status}): ${text.slice(0, 160)}`);
+      }
+      return { ok: true, detail: "Account reachable" };
+    },
+
+    async upload(localPath, remoteName) {
+      const started = Date.now();
+      const body = fs.readFileSync(localPath);
+      const arg = JSON.stringify({ path: `${folderPath(destination)}/${remoteName}`, mode: "overwrite", mute: true });
+      const response = await fetch("https://content.dropboxapi.com/2/files/upload", {
+        method: "POST",
+        headers: {
+          Authorization: await bearer(),
+          "Dropbox-API-Arg": arg,
+          "Content-Type": "application/octet-stream",
+        },
+        body,
+      });
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`Dropbox upload failed (${response.status}): ${text.slice(0, 200)}`);
+      }
+      return { bytes: body.length, durationMs: Date.now() - started };
+    },
+
+    async list() {
+      const response = await fetch("https://api.dropboxapi.com/2/files/list_folder", {
+        method: "POST",
+        headers: { Authorization: await bearer(), "Content-Type": "application/json" },
+        body: JSON.stringify({ path: folderPath(destination) }),
+      });
+      if (response.status === 409) return []; // folder not created yet
+      if (!response.ok) throw new Error(`Dropbox list failed (${response.status})`);
+      const data = await response.json().catch(() => ({}));
+      return (data.entries || [])
+        .filter((entry) => entry[".tag"] === "file" && FILE_PATTERN.test(entry.name || ""))
+        .map((entry) => ({
+          name: entry.name,
+          sizeBytes: Number(entry.size) || 0,
+          createdAt: entry.server_modified || new Date().toISOString(),
+        }))
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    },
+
+    async delete(remoteName) {
+      const response = await fetch("https://api.dropboxapi.com/2/files/delete_v2", {
+        method: "POST",
+        headers: { Authorization: await bearer(), "Content-Type": "application/json" },
+        body: JSON.stringify({ path: `${folderPath(destination)}/${remoteName}` }),
+      });
+      if (!response.ok && response.status !== 409) {
+        throw new Error(`Dropbox delete failed (${response.status})`);
+      }
+    },
+  };
+}

--- a/server/src/utils/backupDestinations/index.js
+++ b/server/src/utils/backupDestinations/index.js
@@ -1,0 +1,33 @@
+// Pluggable remote backup destinations. Each adapter exposes the same contract so
+// the backup lifecycle in watchHistoryBackups.js can treat every target uniformly:
+//
+//   testConnection()              -> { ok, detail }
+//   upload(localPath, remoteName) -> { bytes, durationMs }
+//   list()                        -> [{ name, sizeBytes, createdAt }]
+//   delete(remoteName)            -> void
+//
+// Adapters receive the full destination record ({ id, type, label, settings, secrets })
+// plus a `persistSecrets(partial)` callback used to write back rotated OAuth refresh
+// tokens. Everything goes over the global fetch (undici) — no extra dependencies.
+import { createWebdavAdapter } from "./webdav.js";
+import { createS3Adapter } from "./s3.js";
+import { createOneDriveAdapter } from "./onedrive.js";
+import { createDropboxAdapter } from "./dropbox.js";
+
+export const DESTINATION_TYPES = ["webdav", "s3", "onedrive", "dropbox"];
+
+export function createAdapter(destination, hooks = {}) {
+  const persistSecrets = typeof hooks.persistSecrets === "function" ? hooks.persistSecrets : () => {};
+  switch (destination?.type) {
+    case "webdav":
+      return createWebdavAdapter(destination, { persistSecrets });
+    case "s3":
+      return createS3Adapter(destination, { persistSecrets });
+    case "onedrive":
+      return createOneDriveAdapter(destination, { persistSecrets });
+    case "dropbox":
+      return createDropboxAdapter(destination, { persistSecrets });
+    default:
+      throw new Error(`Unknown backup destination type: ${destination?.type || "(none)"}`);
+  }
+}

--- a/server/src/utils/backupDestinations/onedrive.js
+++ b/server/src/utils/backupDestinations/onedrive.js
@@ -1,0 +1,119 @@
+// OneDrive adapter (Microsoft Graph). Auth is the device-code flow handled in the
+// API layer; this adapter only refreshes the stored refresh token and reads/writes
+// the app folder (approot) so it never touches the rest of the user's drive.
+// Settings: { clientId, tenant?, folder? }  Secrets: { refreshToken }
+import fs from "node:fs";
+
+const FILE_PATTERN = /^plembfin-watch-history-\d{8}T\d{6}Z\.json\.gz$/;
+export const ONEDRIVE_SCOPE = "offline_access Files.ReadWrite.AppFolder";
+
+// access_token cache keyed by destination id (refresh tokens live in the DB).
+const tokenCache = new Map();
+
+export function tokenEndpoint(tenant) {
+  return `https://login.microsoftonline.com/${encodeURIComponent(tenant || "common")}/oauth2/v2.0/token`;
+}
+
+export function deviceCodeEndpoint(tenant) {
+  return `https://login.microsoftonline.com/${encodeURIComponent(tenant || "common")}/oauth2/v2.0/devicecode`;
+}
+
+async function ensureAccessToken(destination, persistSecrets) {
+  const cached = tokenCache.get(destination.id);
+  if (cached && cached.expiresAt > Date.now() + 60000) return cached.accessToken;
+
+  const clientId = destination.settings?.clientId;
+  const refreshToken = destination.secrets?.refreshToken;
+  if (!clientId) throw new Error("OneDrive client ID is required");
+  if (!refreshToken) throw new Error("OneDrive is not connected — run Connect first");
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    scope: ONEDRIVE_SCOPE,
+  });
+  const response = await fetch(tokenEndpoint(destination.settings?.tenant), {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(`OneDrive token refresh failed: ${data.error_description || data.error || response.status}`);
+  }
+  tokenCache.set(destination.id, {
+    accessToken: data.access_token,
+    expiresAt: Date.now() + (Number(data.expires_in) || 3600) * 1000,
+  });
+  // Microsoft rotates refresh tokens — persist the new one so we stay connected.
+  if (data.refresh_token && data.refresh_token !== refreshToken) {
+    destination.secrets.refreshToken = data.refresh_token;
+    persistSecrets({ refreshToken: data.refresh_token });
+  }
+  return data.access_token;
+}
+
+function approotPath(name) {
+  return `https://graph.microsoft.com/v1.0/me/drive/special/approot:/${encodeURIComponent(name)}:`;
+}
+
+export function createOneDriveAdapter(destination, { persistSecrets }) {
+  async function authHeader() {
+    return { Authorization: `Bearer ${await ensureAccessToken(destination, persistSecrets)}` };
+  }
+
+  return {
+    async testConnection() {
+      const headers = await authHeader();
+      const response = await fetch("https://graph.microsoft.com/v1.0/me/drive/special/approot", { headers });
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`OneDrive connection failed (${response.status}): ${text.slice(0, 160)}`);
+      }
+      return { ok: true, detail: "App folder reachable" };
+    },
+
+    async upload(localPath, remoteName) {
+      const started = Date.now();
+      const body = fs.readFileSync(localPath);
+      const headers = await authHeader();
+      const response = await fetch(`${approotPath(remoteName)}/content`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/gzip" },
+        body,
+      });
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`OneDrive upload failed (${response.status}): ${text.slice(0, 200)}`);
+      }
+      return { bytes: body.length, durationMs: Date.now() - started };
+    },
+
+    async list() {
+      const headers = await authHeader();
+      const response = await fetch(
+        "https://graph.microsoft.com/v1.0/me/drive/special/approot/children?$select=name,size,createdDateTime&$top=200",
+        { headers },
+      );
+      if (!response.ok) throw new Error(`OneDrive list failed (${response.status})`);
+      const data = await response.json().catch(() => ({}));
+      return (data.value || [])
+        .filter((item) => FILE_PATTERN.test(item.name || ""))
+        .map((item) => ({
+          name: item.name,
+          sizeBytes: Number(item.size) || 0,
+          createdAt: item.createdDateTime || new Date().toISOString(),
+        }))
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    },
+
+    async delete(remoteName) {
+      const headers = await authHeader();
+      const response = await fetch(approotPath(remoteName), { method: "DELETE", headers });
+      if (!(response.ok || response.status === 204 || response.status === 404)) {
+        throw new Error(`OneDrive delete failed (${response.status})`);
+      }
+    },
+  };
+}

--- a/server/src/utils/backupDestinations/s3.js
+++ b/server/src/utils/backupDestinations/s3.js
@@ -1,0 +1,184 @@
+// S3-compatible adapter (AWS S3, Backblaze B2, MinIO, Wasabi, ...). Implements just
+// enough SigV4 (PUT / GET / DELETE / ListObjectsV2) to avoid pulling in the large
+// @aws-sdk/client-s3 dependency. Settings: { endpoint?, region, bucket, prefix?,
+// accessKeyId, forcePathStyle? }  Secrets: { secretAccessKey }
+import crypto from "node:crypto";
+import fs from "node:fs";
+
+const FILE_PATTERN = /^plembfin-watch-history-\d{8}T\d{6}Z\.json\.gz$/;
+const EMPTY_SHA256 = crypto.createHash("sha256").update("").digest("hex");
+
+function sha256Hex(data) {
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+function hmac(key, data) {
+  return crypto.createHmac("sha256", key).update(data).digest();
+}
+
+// RFC 3986 encoding; S3 keeps "/" as a path separator in the canonical URI.
+function encodeRfc3986(str) {
+  return encodeURIComponent(str).replace(/[!*'()]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
+function encodeKeyPath(key) {
+  return key.split("/").map(encodeRfc3986).join("/");
+}
+
+function s3Config(destination) {
+  const region = String(destination.settings?.region || "us-east-1").trim();
+  const bucket = String(destination.settings?.bucket || "").trim();
+  if (!bucket) throw new Error("S3 bucket is required");
+  const accessKeyId = String(destination.settings?.accessKeyId || "").trim();
+  const secretAccessKey = String(destination.secrets?.secretAccessKey || "").trim();
+  if (!accessKeyId || !secretAccessKey) throw new Error("S3 access key and secret are required");
+  const endpoint = String(destination.settings?.endpoint || `https://s3.${region}.amazonaws.com`)
+    .trim()
+    .replace(/\/+$/, "");
+  // Default to path-style: required by MinIO and most non-AWS providers.
+  const forcePathStyle = destination.settings?.forcePathStyle !== false;
+  let prefix = String(destination.settings?.prefix || "").trim().replace(/^\/+/, "");
+  if (prefix && !prefix.endsWith("/")) prefix += "/";
+  return { region, bucket, accessKeyId, secretAccessKey, endpoint, forcePathStyle, prefix };
+}
+
+function buildUrl(cfg, key, query) {
+  const base = new URL(cfg.endpoint);
+  let host = base.host;
+  let pathname;
+  if (cfg.forcePathStyle) {
+    pathname = `/${cfg.bucket}/${encodeKeyPath(key)}`;
+  } else {
+    host = `${cfg.bucket}.${base.host}`;
+    pathname = `/${encodeKeyPath(key)}`;
+  }
+  const search = query
+    ? `?${Object.keys(query).sort().map((k) => `${encodeRfc3986(k)}=${encodeRfc3986(query[k])}`).join("&")}`
+    : "";
+  return { protocol: base.protocol, host, pathname, search, href: `${base.protocol}//${host}${pathname}${search}` };
+}
+
+async function signedFetch(cfg, { method, key, query, body }) {
+  const url = buildUrl(cfg, key, query);
+  const payload = body || "";
+  const payloadHash = body ? sha256Hex(body) : EMPTY_SHA256;
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, "");
+  const dateStamp = amzDate.slice(0, 8);
+
+  const headers = {
+    host: url.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+  };
+  const signedHeaderNames = Object.keys(headers).sort();
+  const canonicalHeaders = `${signedHeaderNames.map((h) => `${h}:${headers[h]}`).join("\n")}\n`;
+  const signedHeaders = signedHeaderNames.join(";");
+  const canonicalQuery = url.search
+    ? url.search.slice(1)
+    : "";
+
+  const canonicalRequest = [
+    method,
+    url.pathname,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const scope = `${dateStamp}/${cfg.region}/s3/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    scope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+
+  const kDate = hmac(`AWS4${cfg.secretAccessKey}`, dateStamp);
+  const kRegion = hmac(kDate, cfg.region);
+  const kService = hmac(kRegion, "s3");
+  const kSigning = hmac(kService, "aws4_request");
+  const signature = crypto.createHmac("sha256", kSigning).update(stringToSign).digest("hex");
+
+  const authorization = `AWS4-HMAC-SHA256 Credential=${cfg.accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  return fetch(url.href, {
+    method,
+    headers: {
+      Authorization: authorization,
+      "x-amz-content-sha256": payloadHash,
+      "x-amz-date": amzDate,
+      ...(body ? { "Content-Type": "application/gzip" } : {}),
+    },
+    body: body || undefined,
+  });
+}
+
+export function createS3Adapter(destination) {
+  const cfg = s3Config(destination);
+
+  async function listRaw() {
+    const response = await signedFetch(cfg, {
+      method: "GET",
+      key: "",
+      query: { "list-type": "2", prefix: cfg.prefix },
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(`S3 list failed (${response.status}): ${text.slice(0, 200)}`);
+    }
+    return response.text();
+  }
+
+  return {
+    async testConnection() {
+      const response = await signedFetch(cfg, {
+        method: "GET",
+        key: "",
+        query: { "list-type": "2", "max-keys": "1", prefix: cfg.prefix },
+      });
+      if (response.status === 403) throw new Error("S3 access denied (403) — check keys and bucket policy");
+      if (response.status === 404) throw new Error("S3 bucket not found (404)");
+      if (!response.ok) throw new Error(`S3 connection failed (${response.status})`);
+      return { ok: true, detail: `Bucket ${cfg.bucket} reachable` };
+    },
+
+    async upload(localPath, remoteName) {
+      const started = Date.now();
+      const body = fs.readFileSync(localPath);
+      const response = await signedFetch(cfg, { method: "PUT", key: `${cfg.prefix}${remoteName}`, body });
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`S3 upload failed (${response.status}): ${text.slice(0, 200)}`);
+      }
+      return { bytes: body.length, durationMs: Date.now() - started };
+    },
+
+    async list() {
+      const xml = await listRaw();
+      const out = [];
+      const blocks = xml.match(/<Contents>[\s\S]*?<\/Contents>/g) || [];
+      for (const block of blocks) {
+        const key = (block.match(/<Key>([\s\S]*?)<\/Key>/) || [])[1] || "";
+        const name = key.split("/").pop();
+        if (!FILE_PATTERN.test(name)) continue;
+        const size = (block.match(/<Size>(\d+)<\/Size>/) || [])[1];
+        const modified = (block.match(/<LastModified>([\s\S]*?)<\/LastModified>/) || [])[1];
+        out.push({
+          name,
+          sizeBytes: Number(size) || 0,
+          createdAt: modified ? new Date(modified).toISOString() : new Date().toISOString(),
+        });
+      }
+      return out.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    },
+
+    async delete(remoteName) {
+      const response = await signedFetch(cfg, { method: "DELETE", key: `${cfg.prefix}${remoteName}` });
+      if (!(response.ok || response.status === 204 || response.status === 404)) {
+        throw new Error(`S3 delete failed (${response.status})`);
+      }
+    },
+  };
+}

--- a/server/src/utils/backupDestinations/webdav.js
+++ b/server/src/utils/backupDestinations/webdav.js
@@ -1,0 +1,118 @@
+// WebDAV adapter — covers Nextcloud, ownCloud, Apache mod_dav, and most NAS units.
+// Settings: { url, username, directory? }  Secrets: { password }
+import fs from "node:fs";
+import path from "node:path";
+
+const FILE_PATTERN = /^plembfin-watch-history-\d{8}T\d{6}Z\.json\.gz$/;
+
+function baseUrl(destination) {
+  let url = String(destination.settings?.url || "").trim();
+  if (!url) throw new Error("WebDAV URL is required");
+  if (!/^https?:\/\//i.test(url)) throw new Error("WebDAV URL must start with http:// or https://");
+  if (!url.endsWith("/")) url += "/";
+  return url;
+}
+
+function authHeaders(destination) {
+  const username = destination.settings?.username || "";
+  const password = destination.secrets?.password || "";
+  if (!username && !password) return {};
+  const token = Buffer.from(`${username}:${password}`).toString("base64");
+  return { Authorization: `Basic ${token}` };
+}
+
+function remoteUrl(destination, name) {
+  return new URL(encodeURIComponent(name), baseUrl(destination)).toString();
+}
+
+async function ensureCollection(destination) {
+  // MKCOL is a no-op (405/301) when the collection already exists; tolerate that.
+  const response = await fetch(baseUrl(destination), { method: "MKCOL", headers: authHeaders(destination) });
+  if (![200, 201, 204, 301, 405].includes(response.status)) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`WebDAV MKCOL failed (${response.status}): ${body.slice(0, 200)}`);
+  }
+}
+
+export function createWebdavAdapter(destination) {
+  return {
+    async testConnection() {
+      const response = await fetch(baseUrl(destination), {
+        method: "PROPFIND",
+        headers: { ...authHeaders(destination), Depth: "0", "Content-Type": "application/xml" },
+        body: '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop><d:resourcetype/></d:prop></d:propfind>',
+      });
+      if (response.status === 401) throw new Error("WebDAV authentication failed (401)");
+      if (response.status === 404) throw new Error("WebDAV path not found (404)");
+      if (!(response.status === 207 || response.ok)) {
+        throw new Error(`WebDAV connection failed (${response.status})`);
+      }
+      return { ok: true, detail: "Reachable" };
+    },
+
+    async upload(localPath, remoteName) {
+      const started = Date.now();
+      await ensureCollection(destination);
+      const body = fs.readFileSync(localPath);
+      const response = await fetch(remoteUrl(destination, remoteName), {
+        method: "PUT",
+        headers: { ...authHeaders(destination), "Content-Type": "application/gzip" },
+        body,
+      });
+      if (!(response.ok || response.status === 201 || response.status === 204)) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`WebDAV upload failed (${response.status}): ${text.slice(0, 200)}`);
+      }
+      return { bytes: body.length, durationMs: Date.now() - started };
+    },
+
+    async list() {
+      const response = await fetch(baseUrl(destination), {
+        method: "PROPFIND",
+        headers: { ...authHeaders(destination), Depth: "1", "Content-Type": "application/xml" },
+        body: '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop><d:getcontentlength/><d:getlastmodified/></d:prop></d:propfind>',
+      });
+      if (!(response.status === 207 || response.ok)) {
+        throw new Error(`WebDAV list failed (${response.status})`);
+      }
+      const xml = await response.text();
+      return parsePropfind(xml);
+    },
+
+    async delete(remoteName) {
+      const response = await fetch(remoteUrl(destination, remoteName), {
+        method: "DELETE",
+        headers: authHeaders(destination),
+      });
+      if (!(response.ok || response.status === 204 || response.status === 404)) {
+        throw new Error(`WebDAV delete failed (${response.status})`);
+      }
+    },
+  };
+}
+
+// Tolerant PROPFIND parser: namespace prefixes vary (d:, D:, lp1:), so match by
+// local element name and only keep entries whose basename looks like our backups.
+function parsePropfind(xml) {
+  const out = [];
+  const blocks = xml.match(/<[^>]*response[^>]*>[\s\S]*?<\/[^>]*response>/gi) || [];
+  for (const block of blocks) {
+    const href = (block.match(/<[^>]*href[^>]*>([\s\S]*?)<\/[^>]*href>/i) || [])[1];
+    if (!href) continue;
+    let name = "";
+    try {
+      name = decodeURIComponent(path.posix.basename(href.trim().replace(/\/+$/, "")));
+    } catch {
+      name = path.posix.basename(href.trim().replace(/\/+$/, ""));
+    }
+    if (!FILE_PATTERN.test(name)) continue;
+    const sizeRaw = (block.match(/<[^>]*getcontentlength[^>]*>([\s\S]*?)<\/[^>]*getcontentlength>/i) || [])[1];
+    const modRaw = (block.match(/<[^>]*getlastmodified[^>]*>([\s\S]*?)<\/[^>]*getlastmodified>/i) || [])[1];
+    out.push({
+      name,
+      sizeBytes: Number(sizeRaw) || 0,
+      createdAt: modRaw ? new Date(modRaw.trim()).toISOString() : new Date().toISOString(),
+    });
+  }
+  return out.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}

--- a/server/src/utils/watchHistoryBackups.js
+++ b/server/src/utils/watchHistoryBackups.js
@@ -4,11 +4,15 @@ import path from "node:path";
 import zlib from "node:zlib";
 import { bumpDataVersion, db, parseJson, toJson } from "../db.js";
 import { WATCH_HISTORY_BACKUPS_DIR } from "../paths.js";
+import { createAdapter, DESTINATION_TYPES } from "./backupDestinations/index.js";
 
 const FORMAT = "plembfin-watch-history-backup";
 const VERSION = 1;
 const CONFIG_ID = "watchHistoryBackups";
 const RUNTIME_ID = "watchHistoryBackups";
+const DESTINATIONS_ID = "watchBackupDestinations";
+// Secret fields that must never be returned to the browser, per destination type.
+const SECRET_FIELDS = ["password", "secretAccessKey", "appSecret", "refreshToken"];
 const FILE_PATTERN = /^plembfin-watch-history-(\d{8}T\d{6}Z)\.json\.gz$/;
 
 const selectSetting = db.prepare("SELECT data FROM settings WHERE id = ?");
@@ -50,6 +54,145 @@ function saveRuntime(values = {}) {
   const next = { ...current, ...values, updatedAt: Date.now() };
   upsertRuntime.run(RUNTIME_ID, toJson(next), Date.now());
   return next;
+}
+
+// ---- Remote backup destinations --------------------------------------------
+
+function safeDestination(value = {}) {
+  if (!DESTINATION_TYPES.includes(value.type)) throw new Error(`Unsupported destination type: ${value.type}`);
+  return {
+    id: String(value.id || crypto.randomUUID()),
+    type: value.type,
+    label: String(value.label || value.type).slice(0, 120),
+    enabled: Boolean(value.enabled),
+    settings: value.settings && typeof value.settings === "object" ? { ...value.settings } : {},
+    secrets: value.secrets && typeof value.secrets === "object" ? { ...value.secrets } : {},
+  };
+}
+
+export function loadBackupDestinations() {
+  const list = parseJson(selectSetting.get(DESTINATIONS_ID)?.data, []) || [];
+  return Array.isArray(list) ? list.map((item) => ({ ...item, secrets: item.secrets || {}, settings: item.settings || {} })) : [];
+}
+
+function writeBackupDestinations(list) {
+  upsertSetting.run(DESTINATIONS_ID, toJson(list), Date.now());
+}
+
+// Replace secrets with "is-set" boolean flags so the UI never receives credentials.
+function redactDestination(destination) {
+  const secretFlags = {};
+  for (const field of SECRET_FIELDS) {
+    if (destination.secrets?.[field]) secretFlags[field] = true;
+  }
+  return {
+    id: destination.id,
+    type: destination.type,
+    label: destination.label,
+    enabled: destination.enabled,
+    settings: destination.settings || {},
+    secretFlags,
+  };
+}
+
+export function loadBackupDestinationsRedacted() {
+  return loadBackupDestinations().map(redactDestination);
+}
+
+export function getBackupDestination(id) {
+  return loadBackupDestinations().find((item) => item.id === id) || null;
+}
+
+// Upsert a destination. Incoming secret fields overwrite when a non-empty value is
+// supplied, are removed when explicitly null, and are otherwise preserved — so the
+// UI can save settings without re-sending stored credentials.
+export function saveBackupDestination(input = {}) {
+  const list = loadBackupDestinations();
+  const index = list.findIndex((item) => item.id === input.id);
+  const existing = index >= 0 ? list[index] : null;
+  const next = safeDestination({ ...input, id: existing?.id || input.id });
+
+  next.secrets = { ...(existing?.secrets || {}) };
+  if (input.secrets && typeof input.secrets === "object") {
+    for (const [key, value] of Object.entries(input.secrets)) {
+      if (value === null) delete next.secrets[key];
+      else if (value !== undefined && value !== "") next.secrets[key] = value;
+    }
+  }
+
+  if (index >= 0) list[index] = next;
+  else list.push(next);
+  writeBackupDestinations(list);
+  return redactDestination(next);
+}
+
+export function removeBackupDestination(id) {
+  const list = loadBackupDestinations().filter((item) => item.id !== id);
+  writeBackupDestinations(list);
+  const runtime = loadWatchBackupRuntime();
+  if (runtime.destinations?.[id]) {
+    const destinations = { ...runtime.destinations };
+    delete destinations[id];
+    saveRuntime({ destinations });
+  }
+  return { ok: true };
+}
+
+// Merge rotated OAuth refresh tokens (or any secret) back into storage.
+export function updateDestinationSecrets(id, partial = {}) {
+  const list = loadBackupDestinations();
+  const index = list.findIndex((item) => item.id === id);
+  if (index < 0) return;
+  list[index].secrets = { ...(list[index].secrets || {}), ...partial };
+  writeBackupDestinations(list);
+}
+
+function adapterFor(destination) {
+  return createAdapter(destination, {
+    persistSecrets: (partial) => updateDestinationSecrets(destination.id, partial),
+  });
+}
+
+export async function testBackupDestination(destination) {
+  return adapterFor(destination).testConnection();
+}
+
+async function applyRemoteRetention(adapter, retention) {
+  const files = await adapter.list();
+  // Order by filename, not remote-reported mtimes: our names embed a sortable UTC
+  // timestamp, so this is newest-first regardless of how the remote reports dates.
+  const newestFirst = [...files].sort((a, b) => b.name.localeCompare(a.name));
+  for (const file of newestFirst.slice(Math.max(1, retention))) {
+    await adapter.delete(file.name);
+  }
+}
+
+// Mirror a freshly written local backup to every enabled remote. A remote failure is
+// recorded per-destination but never invalidates or deletes the local backup.
+async function pushBackupToRemotes(localAbsolutePath, filename, retention) {
+  const destinations = loadBackupDestinations().filter((item) => item.enabled);
+  if (!destinations.length) return [];
+
+  const statuses = [];
+  for (const destination of destinations) {
+    const lastAttemptAt = Date.now();
+    try {
+      const adapter = adapterFor(destination);
+      const { bytes, durationMs } = await adapter.upload(localAbsolutePath, filename);
+      await applyRemoteRetention(adapter, retention).catch(() => null);
+      statuses.push({ id: destination.id, status: "success", lastAttemptAt, lastSuccessAt: Date.now(), lastError: "", bytes, durationMs });
+    } catch (error) {
+      statuses.push({ id: destination.id, status: "error", lastAttemptAt, lastError: error.message || String(error) });
+    }
+  }
+
+  const runtime = loadWatchBackupRuntime();
+  const map = { ...(runtime.destinations || {}) };
+  for (const { id, ...rest } of statuses) {
+    map[id] = { ...(map[id] || {}), ...rest };
+  }
+  saveRuntime({ destinations: map });
+  return statuses;
 }
 
 function essentialWatchHistory() {
@@ -134,7 +277,7 @@ function applyRetention(retention) {
   }
 }
 
-export function createWatchHistoryBackup({ reason = "manual" } = {}) {
+export async function createWatchHistoryBackup({ reason = "manual" } = {}) {
   fs.mkdirSync(WATCH_HISTORY_BACKUPS_DIR, { recursive: true });
   const document = backupDocument();
   const json = Buffer.from(`${JSON.stringify(document)}\n`, "utf8");
@@ -160,6 +303,9 @@ export function createWatchHistoryBackup({ reason = "manual" } = {}) {
     reason,
   };
   saveRuntime({ lastSuccessAt: Date.now(), lastError: "", lastBackup: result, lastRunDate: localDateKey() });
+  // Local backup is verified and durable; remote mirroring is best-effort and must
+  // not throw back into the caller.
+  result.remotes = await pushBackupToRemotes(destination, filename, config.retention).catch(() => []);
   return result;
 }
 
@@ -273,10 +419,11 @@ export function watchBackupStatus() {
     config: loadWatchBackupConfig(),
     runtime: loadWatchBackupRuntime(),
     files: listWatchBackups(),
+    destinations: loadBackupDestinationsRedacted(),
   };
 }
 
-export function runScheduledWatchBackup() {
+export async function runScheduledWatchBackup() {
   const config = loadWatchBackupConfig();
   if (!config.enabled) return null;
   const now = new Date();
@@ -285,7 +432,7 @@ export function runScheduledWatchBackup() {
   const runtime = loadWatchBackupRuntime();
   if (runtime.lastRunDate === today || currentTime < config.time) return null;
   try {
-    return createWatchHistoryBackup({ reason: "scheduled" });
+    return await createWatchHistoryBackup({ reason: "scheduled" });
   } catch (error) {
     saveRuntime({ lastError: error.message || String(error), lastFailureAt: Date.now(), lastRunDate: today });
     throw error;


### PR DESCRIPTION
## What

Two changes from the Settings → Backups area.

### 1. Remote backup destinations (OneDrive, Dropbox, WebDAV, S3)
The Destination dropdown was hardcoded to local-only. This adds a pluggable adapter system under `server/src/utils/backupDestinations/` (one file per target, shared `testConnection / upload / list / delete` contract) and a **Remote Destinations** manager in Settings → Backups.

- Local gzip backup is always written and verified **first**, then mirrored best-effort to each enabled remote.
- A remote failure is recorded per-destination and **never** invalidates or deletes the local backup.
- Remote retention is ordered by the sortable backup filename (deterministic regardless of remote clock).
- Credentials are stored server-side (`watchBackupDestinations` settings row) and **redacted to is-set flags** in every API response.
- **OneDrive**: Microsoft device-code flow (user supplies their own Azure app client ID).
- **Dropbox**: no-redirect OAuth code flow. Both store a refresh token.
- **S3**: hand-rolled SigV4 (no AWS SDK dependency) — AWS / MinIO / B2 / Wasabi.

### 2. Fix: can't mark a non-library movie watched
The TMDB movie modal showed a static "Unwatched" with no action. It now offers **Mark watched** (via the existing watch-date prompt) and reflects watched state from local history.

## Verification
Ran the server + a mock WebDAV server:
- Redaction on save; secrets preserved on re-save without resending ✓
- Test failures / OAuth guards return clean errors ✓
- Backup with a failing remote enabled → **local still succeeds**, failure recorded ✓
- WebDAV round-trip: 3 backups at retention=2 → local and remote both keep the 2 newest and match ✓
- `/api/manual-watch` for a movie in no library → persists in history ✓

⚠️ OneDrive/Dropbox/S3 happy-paths need a live smoke test with real credentials (protocols standard; failure/auth-guard paths verified). Setup is documented in `docs/watch-history-backups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)