### PR TITLE
Make backup restore authoritative; stop cron re-importing as watched-today

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -613,7 +613,21 @@ function renderWatchBackups() {
     ? `<div class="empty-log" style="padding: var(--space-2);"><span>Loading remote backups…</span></div>`
     : "";
 
-  elements.watchBackupList.innerHTML = cronPausedBanner + remoteLoading + (allEntries.length ? allEntries.map((entry) => `
+  const clearMode = state.restoreClearMode || "reconcile";
+  const clearModeSelector = `
+    <div class="restore-clear-mode backup-runtime" style="margin-bottom: var(--space-3); display: grid; gap: var(--space-2);">
+      <div style="font-weight: 600;">Restoring makes this backup the source of truth — it is pushed to every connected app. Choose how to clear the apps first:</div>
+      <label style="display: flex; gap: var(--space-2); align-items: flex-start; cursor: pointer;">
+        <input type="radio" name="restoreClearMode" value="reconcile" ${clearMode === "reconcile" ? "checked" : ""} data-restore-clear-mode style="margin-top: 3px;">
+        <span><b>Reconcile tracked items</b> — push only the items this backup knows about. Fast. Apps keep any extra watched items the backup never tracked.</span>
+      </label>
+      <label style="display: flex; gap: var(--space-2); align-items: flex-start; cursor: pointer;">
+        <input type="radio" name="restoreClearMode" value="wipe" ${clearMode === "wipe" ? "checked" : ""} data-restore-clear-mode style="margin-top: 3px;">
+        <span><b>Full wipe then push</b> — mark every currently-watched item on each app as unwatched, then re-apply only the backup's watched set. Apps end up matching the backup exactly. Slower.</span>
+      </label>
+    </div>`;
+
+  elements.watchBackupList.innerHTML = cronPausedBanner + (allEntries.length ? clearModeSelector : "") + remoteLoading + (allEntries.length ? allEntries.map((entry) => `
     <article class="watch-backup-row">
       <div class="watch-backup-copy">
         <b>${escapeHtml(entry.name)}</b>
@@ -625,7 +639,6 @@ function renderWatchBackups() {
       <div class="watch-backup-actions">
         <button class="button-primary" type="button"
           data-watch-backup-restore="${escapeAttribute(entry.name)}"
-          data-restore-mode="replace"
           ${entry.destId ? `data-restore-dest-id="${escapeAttribute(entry.destId)}"` : ""}>
           Watch History Wipe / Restore
         </button>
@@ -920,29 +933,25 @@ async function listRemoteBackupsForCard(card) {
           <span>${escapeHtml(watchBackupDate(file.createdAt))} · ${escapeHtml(formatBytes(file.sizeBytes))}</span>
         </div>
         <div class="watch-backup-actions">
-          <button class="button-primary" type="button" data-dest-restore-file="${escapeAttribute(file.name)}" data-restore-mode="merge">Merge Restore</button>
-          <button class="button-danger" type="button" data-dest-restore-file="${escapeAttribute(file.name)}" data-restore-mode="replace">Replace</button>
+          <button class="button-danger" type="button" data-dest-restore-file="${escapeAttribute(file.name)}">Wipe / Restore</button>
         </div>
       </div>
     `).join("")}
   `;
 }
 
-async function restoreRemoteBackupFromCard(card, filename, mode) {
+async function restoreRemoteBackupFromCard(card, filename, clearMode = "reconcile") {
+  const wipe = clearMode === "wipe";
   const approved = await openConfirmDialog({
     title: "⚠️ Watch History Wipe / Restore",
-    body: `This will DELETE all current watch history, playstate, and resume progress, then fully restore from:\n\n${filename}\n\nThis cannot be undone. After restore, the cron will permanently ignore items played before the restore date.`,
-    confirmLabel: "Wipe and Restore",
+    body: `⚠️ AUTHORITATIVE RESTORE — this backup becomes the source of truth.\n\nWill DELETE all current watch history, playstate and resume progress, restore from:\n\n${filename}\n\nand push that state to every connected app.\n\n${wipe
+      ? "Clear mode: FULL WIPE — every currently-watched item on each app is first marked unwatched."
+      : "Clear mode: RECONCILE — only items tracked by the backup are pushed."}\n\nThis cannot be undone.`,
+    confirmLabel: wipe ? "Wipe Apps and Restore" : "Restore and Push",
     danger: true,
   });
   if (!approved) return;
-  const result = await postWatchBackupAction({ action: "restore-remote-backup", destinationId: card.dataset.destId, filename, mode });
-  const summary = result.restore || {};
-  clearDerivedUiCaches();
-  await Promise.all([loadHistory({ force: true }), loadStats({ force: true })]);
-  state.watchBackups = null;
-  await loadWatchBackups({ force: true });
-  setMessage(`Restored from ${filename} (${mode}): ${summary.watchHistory || 0} history, ${summary.playstate || 0} playstate rows.`, "success");
+  await runAuthoritativeRestore({ action: "restore-remote-backup", destinationId: card.dataset.destId, filename, clearMode });
 }
 
 async function connectBackupDestinationCard(card) {
@@ -1062,57 +1071,93 @@ async function downloadWatchBackup(filename) {
   URL.revokeObjectURL(url);
 }
 
-async function restoreWatchBackup(filename, mode, dryRun = false) {
-  if (!dryRun) {
-    const approved = await openConfirmDialog({
-      title: mode === "replace" ? "⚠️ Wipe and restore watch history?" : "Merge watch history?",
-      body: mode === "replace"
-        ? `⚠️ WATCH HISTORY WIPE / RESTORE:\n\nWill DELETE all current watch history and restore from ${filename}.\n\nUse this if:\n• Your current data is corrupted or contains false entries\n• You want to completely reset to the backup state\n• You want to restore to a previous point in time\n\nAfter restore, the cron will skip any items from connected apps that were played before the restore date, so stale data cannot re-enter.`
-        : `MERGE RESTORE (keep both old and new):\n\nWill keep entries from both the backup AND current data.\n\nUse this only if:\n• Your backup is older\n• You have new legitimate watch entries since the backup\n• You're certain current data is NOT corrupted`,
-      confirmLabel: mode === "replace" ? "Wipe and Restore" : "Merge Restore",
-      danger: mode === "replace",
-    });
-    if (!approved) return;
+async function restoreWatchBackup(filename, clearMode = "reconcile", dryRun = false) {
+  if (dryRun) {
+    const result = await postWatchBackupAction({ action: "restore", filename, dryRun: true });
+    const summary = result.restore || {};
+    setMessage(`Backup valid: ${summary.watchHistory || 0} history, ${summary.playstate || 0} playstate, ${summary.playbackProgress || 0} progress rows.`, "success");
+    return;
   }
 
+  const wipe = clearMode === "wipe";
+  const approved = await openConfirmDialog({
+    title: "⚠️ Wipe and restore watch history?",
+    body: `⚠️ AUTHORITATIVE RESTORE — this backup becomes the source of truth.\n\nWill DELETE all current watch history, playstate and resume progress, restore from ${filename}, and push that state to every connected app (Plex/Emby/Jellyfin).\n\n${wipe
+      ? "Clear mode: FULL WIPE — every currently-watched item on each app is first marked unwatched, so the apps end up matching the backup exactly."
+      : "Clear mode: RECONCILE — only items tracked by the backup are pushed; extra watched items on the apps are left as-is."}\n\nThis cannot be undone.`,
+    confirmLabel: wipe ? "Wipe Apps and Restore" : "Restore and Push",
+    danger: true,
+  });
+  if (!approved) return;
+
+  await runAuthoritativeRestore({ action: "restore", filename, clearMode });
+}
+
+// Shared driver for both local and remote authoritative restores: kick off the background job,
+// stream its log into the restore terminal, then refresh the UI.
+async function runAuthoritativeRestore(payload) {
   const terminal = document.querySelector("#restoreProgressTerminal");
-  if (terminal && !dryRun && mode === "replace") {
+  if (terminal) {
     terminal.classList.remove("hidden");
-    terminal.textContent = "[Starting] Preparing to restore watch history...\n";
+    terminal.textContent = "[Starting] Preparing authoritative restore...\n";
   }
 
   try {
-    const result = await postWatchBackupAction({ action: "restore", filename, mode, dryRun });
+    const result = await postWatchBackupAction(payload);
     const summary = result.restore || {};
-
-    if (dryRun) {
-      setMessage(`Backup valid: ${summary.watchHistory || 0} history, ${summary.playstate || 0} playstate, ${summary.playbackProgress || 0} progress rows.`, "success");
-      return;
+    if (terminal) {
+      terminal.textContent += `[${new Date().toLocaleTimeString()}] Restored ${summary.watchHistory || 0} history, ${summary.playstate || 0} playstate, ${summary.playbackProgress || 0} progress records\n`;
+      terminal.textContent += `[${new Date().toLocaleTimeString()}] Pushing to connected apps (clear mode: ${result.clearMode || payload.clearMode || "reconcile"})...\n`;
     }
 
-    if (terminal && mode === "replace") {
-      terminal.textContent += `[${new Date().toLocaleTimeString()}] Restored ${summary.watchHistory || 0} watch history records\n`;
-      terminal.textContent += `[${new Date().toLocaleTimeString()}] Restored ${summary.playstate || 0} playstate records\n`;
-      terminal.textContent += `[${new Date().toLocaleTimeString()}] Restored ${summary.playbackProgress || 0} progress records\n`;
-      terminal.textContent += `[${new Date().toLocaleTimeString()}] Syncing to connected apps...\n`;
-    }
+    const jobResult = await pollRestoreProgress(terminal);
 
     clearDerivedUiCaches();
     await Promise.all([loadHistory({ force: true }), loadStats({ force: true })]);
     state.watchBackups = null;
     await loadWatchBackups({ force: true });
 
-    if (terminal && mode === "replace") {
-      terminal.textContent += `[${new Date().toLocaleTimeString()}] ✓ Restore complete!\n`;
+    if (jobResult && jobResult.success === false) {
+      setMessage(`Restore finished with errors: ${jobResult.error || "see terminal"}.`, "error");
+    } else {
+      setMessage(`Watch history restored from ${payload.filename} and pushed to connected apps.`, "success");
     }
-
-    setMessage(`Watch history restored from ${filename}.`, "success");
   } catch (error) {
-    if (terminal && mode === "replace") {
-      terminal.textContent += `[ERROR] ${error.message}\n`;
-    }
+    if (terminal) terminal.textContent += `[ERROR] ${error.message}\n`;
     throw error;
   }
+}
+
+// Poll the watch-backups status endpoint, appending new restore-job log lines to the terminal
+// until the job is no longer active. Returns the job result.
+async function pollRestoreProgress(terminal) {
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  let printed = 0;
+  for (let i = 0; i < 600; i++) {
+    let data;
+    try {
+      const response = await fetch("/api/watch-backups", { headers: authHeaders(), cache: "no-store" });
+      data = await response.json().catch(() => ({}));
+    } catch {
+      await sleep(2000);
+      continue;
+    }
+    const rs = data.restoreSync || {};
+    const log = Array.isArray(rs.log) ? rs.log : [];
+    if (terminal && log.length > printed) {
+      for (let j = printed; j < log.length; j++) terminal.textContent += `${log[j]}\n`;
+      terminal.scrollTop = terminal.scrollHeight;
+      printed = log.length;
+    }
+    if (rs.active !== true) {
+      if (terminal && rs.result && rs.result.success === false) {
+        terminal.textContent += `[ERROR] ${rs.result.error || "Restore reconcile failed"}\n`;
+      }
+      return rs.result || null;
+    }
+    await sleep(2000);
+  }
+  return null;
 }
 
 async function apiUpdateWatch(id, fields) {
@@ -9273,17 +9318,25 @@ function attachEvents() {
     }
     const dryRun = event.target.closest("[data-watch-backup-dry-run]");
     if (dryRun) {
-      restoreWatchBackup(dryRun.dataset.watchBackupDryRun, "merge", true).catch((error) => setMessage(error.message, "error"));
+      restoreWatchBackup(dryRun.dataset.watchBackupDryRun, "reconcile", true).catch((error) => setMessage(error.message, "error"));
       return;
     }
     const restore = event.target.closest("[data-watch-backup-restore]");
     if (restore) {
+      const clearMode = state.restoreClearMode || "reconcile";
       const destId = restore.dataset.restoreDestId;
       if (destId) {
-        restoreRemoteBackupFromCard({ dataset: { destId } }, restore.dataset.watchBackupRestore, restore.dataset.restoreMode || "replace").catch((error) => setMessage(error.message, "error"));
+        restoreRemoteBackupFromCard({ dataset: { destId } }, restore.dataset.watchBackupRestore, clearMode).catch((error) => setMessage(error.message, "error"));
       } else {
-        restoreWatchBackup(restore.dataset.watchBackupRestore, restore.dataset.restoreMode || "replace").catch((error) => setMessage(error.message, "error"));
+        restoreWatchBackup(restore.dataset.watchBackupRestore, clearMode).catch((error) => setMessage(error.message, "error"));
       }
+    }
+  });
+
+  elements.watchBackupList?.addEventListener("change", (event) => {
+    const clearModeInput = event.target.closest("[data-restore-clear-mode]");
+    if (clearModeInput) {
+      state.restoreClearMode = clearModeInput.value === "wipe" ? "wipe" : "reconcile";
     }
   });
 
@@ -9303,7 +9356,7 @@ function attachEvents() {
     const restoreFile = event.target.closest("[data-dest-restore-file]");
     if (restoreFile) {
       const card = restoreFile.closest("[data-dest-id]");
-      if (card) restoreRemoteBackupFromCard(card, restoreFile.dataset.destRestoreFile, restoreFile.dataset.restoreMode || "merge").catch((error) => setMessage(error.message, "error"));
+      if (card) restoreRemoteBackupFromCard(card, restoreFile.dataset.destRestoreFile, state.restoreClearMode || "reconcile").catch((error) => setMessage(error.message, "error"));
       return;
     }
     const button = event.target.closest("[data-dest-action]");

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,8 +1,8 @@
 import crypto from "node:crypto";
 import { normalizeProviderIds, parseCustomWebhook, parseEmbyWebhook, parseJellyfinWebhook, parsePlexWebhook } from "./utils/parsers.js";
-import { findPlexItem, markPlexPlayed, setPlexProgress } from "./utils/plexClient.js";
-import { markEmbyPlayed, setEmbyProgress } from "./utils/embyClient.js";
-import { markJellyfinPlayed, setJellyfinProgress } from "./utils/jellyfinClient.js";
+import { findPlexItem, markPlexPlayed, setPlexProgress, markPlexUnplayedByRatingKey, fetchPlexWatchedItems } from "./utils/plexClient.js";
+import { markEmbyPlayed, setEmbyProgress, markEmbyUnplayedById, fetchEmbyWatchedItems } from "./utils/embyClient.js";
+import { markJellyfinPlayed, setJellyfinProgress, markJellyfinUnplayedById, fetchJellyfinWatchedItems } from "./utils/jellyfinClient.js";
 import { requireAdmin, requireAdminStreaming, handleLogin, handleLogout, handleAuthStatus, handleAuthCredentials } from "./utils/auth.js";
 import { AUTH } from "./appConfig.js";
 import { getLogs as getDiagnosticLogs, clearLogs as clearDiagnosticLogs } from "./utils/diagnosticLogger.js";
@@ -78,6 +78,8 @@ import {
   clearRestoreStatus,
   pauseCronSync,
   resumeCronSync,
+  setLastRestoreAt,
+  loadWatchBackupRuntime,
   restoreWatchHistoryBackup,
   runScheduledWatchBackup,
   saveWatchBackupConfig,
@@ -626,13 +628,232 @@ async function exchangeDropboxCode(destination, code) {
   return { status: "authorized" };
 }
 
+// Small forward cushion so an app-recorded "viewedAt" stamped a moment after our push
+// can't land just past lastRestoreAt and get re-imported. See setLastRestoreAt().
+const RESTORE_SKEW_BUFFER_MS = 5000;
+
+// Batched runtime-log writer (mirrors the Force-Sync pattern): collect lines in memory and
+// flush to runtime_state every `intervalMs` so we don't write per line.
+function createBatchedRuntimeLogger(field, { intervalMs = 2000 } = {}) {
+  const buffer = [];
+  let timer = null;
+  const flush = async () => {
+    if (!buffer.length) return;
+    const batch = buffer.splice(0, buffer.length);
+    await appendRuntimeLog(field, batch).catch(() => null);
+  };
+  const log = (msg) => {
+    console.log(msg);
+    buffer.push(msg);
+    if (!timer) {
+      timer = setTimeout(async () => {
+        timer = null;
+        await flush();
+      }, intervalMs);
+    }
+  };
+  const stop = async () => {
+    if (timer) { clearTimeout(timer); timer = null; }
+    await flush();
+  };
+  return { log, stop };
+}
+
+function mediaFromPlaystateRow(row) {
+  const media = {
+    title: row.title,
+    type: row.media_type,
+    source: "restore",
+    isValid: true,
+    ids: {
+      imdb: row.imdb_id || undefined,
+      tmdb: row.tmdb_id || undefined,
+      tvdb: row.tvdb_id || undefined,
+    },
+  };
+  if (String(row.media_type) === "episode") {
+    media.season = row.season != null ? Number(row.season) : undefined;
+    media.episode = row.episode != null ? Number(row.episode) : undefined;
+  }
+  return media;
+}
+
+// Push the just-restored playstate to every connected app. `source: "restore"` makes
+// getTargetsForSource fan out to all three platforms.
+async function pushRestoredStateToApps(config, logLine) {
+  const loopStore = createLoopStore();
+  const rows = requireDb().prepare("SELECT * FROM playstate").all();
+  logLine(`Pushing ${rows.length} restored item(s) to connected apps...`);
+  let done = 0;
+  let watched = 0;
+  let unwatched = 0;
+  let failed = 0;
+  for (const row of rows) {
+    const media = mediaFromPlaystateRow(row);
+    const isWatched = String(row.state || "watched").toLowerCase() !== "unwatched";
+    try {
+      if (isWatched) {
+        await syncMediaPlaystate(media, config, loopStore);
+        watched++;
+      } else {
+        await syncMediaUnplayedPlaystate(media, config, loopStore);
+        unwatched++;
+      }
+    } catch (error) {
+      failed++;
+      logLine(`  ! Failed to push "${media.title}": ${error.message}`);
+    }
+    done++;
+    if (done % 25 === 0 || done === rows.length) {
+      logLine(`  Pushed ${done}/${rows.length} (watched ${watched}, unwatched ${unwatched}, failed ${failed})`);
+    }
+  }
+  return { total: rows.length, watched, unwatched, failed };
+}
+
+// Full-wipe clear pass: mark every item each app currently reports as watched as unwatched,
+// so that the subsequent push re-marks only the backup's watched set and the apps end up
+// matching the backup exactly. Operates on native item ids (no re-resolution).
+async function clearAppWatchstates(config, logLine) {
+  const summary = { plex: 0, emby: 0, jellyfin: 0, failed: 0 };
+  const plexActive = !config?.plex?.disabled && Boolean(config?.plex?.baseUrl && config?.plex?.token);
+  const embyActive = !config?.emby?.disabled && Boolean(config?.emby?.baseUrl && config?.emby?.apiKey && config?.emby?.userId);
+  const jellyfinActive = !config?.jellyfin?.disabled && Boolean(config?.jellyfin?.baseUrl && config?.jellyfin?.apiKey && config?.jellyfin?.userId);
+
+  if (plexActive) {
+    try {
+      const items = await fetchPlexWatchedItems(config.plex);
+      logLine(`Clearing ${items.length} watched item(s) on Plex...`);
+      for (const item of items) {
+        try {
+          await markPlexUnplayedByRatingKey(config.plex, item.ratingKey || item.key);
+          summary.plex++;
+        } catch (error) {
+          summary.failed++;
+        }
+      }
+    } catch (error) {
+      logLine(`  ! Plex clear failed: ${error.message}`);
+    }
+  }
+  if (embyActive) {
+    try {
+      const items = await fetchEmbyWatchedItems(config.emby);
+      logLine(`Clearing ${items.length} watched item(s) on Emby...`);
+      for (const item of items) {
+        try {
+          await markEmbyUnplayedById(config.emby, item.Id);
+          summary.emby++;
+        } catch (error) {
+          summary.failed++;
+        }
+      }
+    } catch (error) {
+      logLine(`  ! Emby clear failed: ${error.message}`);
+    }
+  }
+  if (jellyfinActive) {
+    try {
+      const items = await fetchJellyfinWatchedItems(config.jellyfin);
+      logLine(`Clearing ${items.length} watched item(s) on Jellyfin...`);
+      for (const item of items) {
+        try {
+          await markJellyfinUnplayedById(config.jellyfin, item.Id);
+          summary.jellyfin++;
+        } catch (error) {
+          summary.failed++;
+        }
+      }
+    } catch (error) {
+      logLine(`  ! Jellyfin clear failed: ${error.message}`);
+    }
+  }
+  return summary;
+}
+
+// Background reconcile job, kicked off after the synchronous DB restore. Optionally wipes app
+// watchstates, pushes the restored state to all apps, then stamps lastRestoreAt (AFTER the push
+// so the pushes themselves fall under the cron's pre-restore filter) and clears the active flag.
+async function runRestoreReconcileJob(clearMode) {
+  const { log, stop } = createBatchedRuntimeLogger("restoreSyncLog");
+  let result;
+  try {
+    const config = await loadMediaConfig();
+    if (clearMode === "wipe") {
+      log("Clear mode: full wipe — marking every watched item on each app as unwatched.");
+      const cleared = await clearAppWatchstates(config, log);
+      log(`Clear complete: Plex ${cleared.plex}, Emby ${cleared.emby}, Jellyfin ${cleared.jellyfin}, failed ${cleared.failed}.`);
+    } else {
+      log("Clear mode: reconcile — pushing only items tracked by the backup.");
+    }
+    const pushed = await pushRestoredStateToApps(config, log);
+    log(`Push complete: ${pushed.watched} watched, ${pushed.unwatched} unwatched, ${pushed.failed} failed.`);
+    result = { success: true, clearMode, pushed };
+  } catch (error) {
+    log(`ERROR: Restore reconcile failed: ${error.message}`);
+    result = { success: false, error: error.message };
+  } finally {
+    // Always advance the watermark: after a successful DB restore the local DB IS the backup,
+    // so the cron should ignore any app history at/before now regardless of push outcome.
+    const stampedAt = Date.now() + RESTORE_SKEW_BUFFER_MS;
+    setLastRestoreAt(stampedAt);
+    log(`Stamped lastRestoreAt = ${new Date(stampedAt).toISOString()}; cron will skip app history up to this point.`);
+    log("✓ Authoritative restore complete.");
+    await stop();
+    await setRuntimeState({ restoreSyncActive: false, restoreSyncResult: result || { success: false } }).catch(() => null);
+  }
+  return result;
+}
+
+// Run the synchronous DB restore, then kick off the background clear/push job. Shared by the
+// local "restore" and remote "restore-remote-backup" actions. Returns the response payload.
+async function startAuthoritativeRestore(filename, clearMode) {
+  const runtime = await loadRuntimeState();
+  const tenMinutesAgo = Date.now() - 10 * 60 * 1000;
+  if (runtime.restoreSyncActive === true && runtime.restoreSyncStartedAt && runtime.restoreSyncStartedAt > tenMinutesAgo) {
+    return { status: 409, body: { ok: false, error: "An authoritative restore is already running." } };
+  }
+
+  // Mark active BEFORE touching the DB so the cron + webhook stop importing immediately.
+  await setRuntimeState({
+    restoreSyncActive: true,
+    restoreSyncStartedAt: Date.now(),
+    restoreSyncResult: null,
+    restoreSyncLog: [`Authoritative restore started (${clearMode}) from ${filename}...`],
+  });
+
+  let restore;
+  try {
+    restore = restoreWatchHistoryBackup(filename, { mode: "replace", dryRun: false });
+  } catch (error) {
+    await setRuntimeState({ restoreSyncActive: false, restoreSyncResult: { success: false, error: error.message } }).catch(() => null);
+    return { status: 400, body: { error: error.message } };
+  }
+
+  // Fire-and-forget — the job stamps lastRestoreAt and clears the flag when it finishes.
+  runRestoreReconcileJob(clearMode);
+
+  return { status: 202, body: { ok: true, restore, clearMode, jobStarted: true } };
+}
+
 async function handleWatchBackups(req, res) {
   if (req.method === "OPTIONS") return sendOptions(res);
   if (!(await requireAdmin(req, res))) return;
 
   if (req.method === "GET") {
     const filename = String(req.query?.download || "").trim();
-    if (!filename) return sendJson(res, watchBackupStatus());
+    if (!filename) {
+      const runtime = await loadRuntimeState();
+      return sendJson(res, {
+        ...watchBackupStatus(),
+        restoreSync: {
+          active: runtime.restoreSyncActive === true,
+          log: Array.isArray(runtime.restoreSyncLog) ? runtime.restoreSyncLog : [],
+          result: runtime.restoreSyncResult || null,
+          startedAt: runtime.restoreSyncStartedAt || null,
+        },
+      });
+    }
     try {
       const file = readWatchBackupFile(filename);
       res.statusCode = 200;
@@ -660,32 +881,18 @@ async function handleWatchBackups(req, res) {
       const filename = String(body.filename || "").trim();
       if (!filename) return sendJson(res, { error: "filename is required" }, 400);
 
-      const mode = body.mode === "replace" ? "replace" : "merge";
       const dryRun = body.dryRun === true;
-
       if (dryRun) {
+        // Replace-only: restore is always authoritative; merge is no longer offered.
         return sendJson(res, {
           ok: true,
-          restore: restoreWatchHistoryBackup(filename, { mode, dryRun: true }),
+          restore: restoreWatchHistoryBackup(filename, { mode: "replace", dryRun: true }),
         });
       }
 
-      // For Replace restores: the restore sets lastRestoreAt in runtime state, which the cron uses
-      // to permanently filter out any items played before the restore date. No pause needed.
-      if (mode === "replace") {
-        const result = restoreWatchHistoryBackup(filename, { mode, dryRun: false });
-
-        return sendJson(res, {
-          ok: true,
-          restore: result,
-        });
-      }
-
-      // For Merge restores, just restore without pausing cron
-      return sendJson(res, {
-        ok: true,
-        restore: restoreWatchHistoryBackup(filename, { mode, dryRun: false }),
-      });
+      const clearMode = body.clearMode === "wipe" ? "wipe" : "reconcile";
+      const { status, body: payload } = await startAuthoritativeRestore(filename, clearMode);
+      return sendJson(res, payload, status);
     }
     if (action === "save-destination") {
       return sendJson(res, { ok: true, destination: saveBackupDestination(body.destination || {}) });
@@ -703,15 +910,19 @@ async function handleWatchBackups(req, res) {
     if (action === "restore-remote-backup") {
       const id = String(body.destinationId || "").trim();
       const filename = String(body.filename || "").trim();
-      const remoteMode = body.mode === "replace" ? "replace" : "merge";
       const remoteDryRun = body.dryRun === true;
       if (!id || !filename) return sendJson(res, { error: "destinationId and filename are required" }, 400);
       const pulled = await pullRemoteBackupToLocal(id, filename);
-      return sendJson(res, {
-        ok: true,
-        pulled,
-        restore: restoreWatchHistoryBackup(pulled.name, { mode: remoteMode, dryRun: remoteDryRun }),
-      });
+      if (remoteDryRun) {
+        return sendJson(res, {
+          ok: true,
+          pulled,
+          restore: restoreWatchHistoryBackup(pulled.name, { mode: "replace", dryRun: true }),
+        });
+      }
+      const clearMode = body.clearMode === "wipe" ? "wipe" : "reconcile";
+      const { status, body: payload } = await startAuthoritativeRestore(pulled.name, clearMode);
+      return sendJson(res, { ...payload, pulled }, status);
     }
     if (action === "clear-restore-status") {
       return sendJson(res, { ok: true, ...clearRestoreStatus() });
@@ -1200,6 +1411,24 @@ async function handleWebhook(req, res) {
       reason: "Unsupported event or missing provider IDs",
       debug: media.rawPayloadDebug,
     });
+  }
+
+  // While an authoritative restore is pushing fresh state to the apps, ignore inbound
+  // webhooks — they are the apps echoing our own marks back and would re-record as
+  // watched-today. Real user plays resume the moment the restore job finishes.
+  const restoreRuntime = await loadRuntimeState();
+  if (restoreRuntime.restoreSyncActive === true) {
+    console.log("Webhook ignored: authoritative restore in progress (suppressing app echo)", {
+      source: media.source,
+      title: media.title,
+      phase: media.phase,
+    });
+    await recordSyncHistory(media, {
+      status: "skipped",
+      details: "Webhook ignored: authoritative restore in progress",
+      targetStates: [],
+    }, media.phase || "webhook").catch(() => null);
+    return sendJson(res, { ok: true, inserted: false, skipped: true, reason: "Authoritative restore in progress" });
   }
 
   const config = await loadMediaConfig();

--- a/server/src/scheduled.js
+++ b/server/src/scheduled.js
@@ -405,6 +405,14 @@ async function processCompletedSession(row, config, loopStore) {
   const media = cachedRowToMedia(row);
   if (!media.isValid || Number(media.progress || 0) < 90) return null;
 
+  // After an authoritative restore, drop stale cached sessions whose last update predates the
+  // restore — they would otherwise post a watch record dated today. Sessions still genuinely
+  // active get re-cached with a fresh timestamp each tick, so real playback still completes.
+  const lastRestoreAt = Number(loadWatchBackupRuntime().lastRestoreAt || 0);
+  if (lastRestoreAt && Number(row.updated_at || 0) <= lastRestoreAt) {
+    return null;
+  }
+
   await markLiveTrackingComplete(requireDb(), row.session_id, Date.now());
 
   const watchRecord = mediaToWatchRecord(
@@ -493,6 +501,14 @@ async function syncResumableMedia(media, config, loopStore, logger = console.log
   const existingPlaystate = await getPlaystateForMedia(requireDb(), media).catch(() => null);
   const resumeUpdatedAt = Number(media.updatedAt || 0);
   const playstateUpdatedAt = Number(existingPlaystate?.updated_at || 0);
+
+  // After an authoritative restore, ignore resume positions whose app-side timestamp predates
+  // the restore — they are pre-restore state the backup has already superseded.
+  const lastRestoreAt = Number(loadWatchBackupRuntime().lastRestoreAt || 0);
+  if (lastRestoreAt && resumeUpdatedAt > 0 && resumeUpdatedAt <= lastRestoreAt) {
+    logger(`Resume Sync: ${media.title} from ${media.source} -> skipped (pre-restore resume position)`);
+    return false;
+  }
 
   if (existingPlaystate) {
     logger(`Resume Sync: ${media.title} from ${media.source} - checking playstate`, {
@@ -1099,8 +1115,17 @@ export async function runScheduledSync(logger = console.log) {
     runtime.forceSyncActive = false;
   }
 
-  if (runtime.rebuildActive === true || runtime.forceSyncActive === true) {
-    logger("Scheduled Sync: skipped because a database rebuild or force sync is currently active.");
+  // Reset a restore-reconcile flag that got stuck (e.g. process crashed mid-job) so the cron
+  // isn't blocked forever.
+  const isRestoreSyncStale = runtime.restoreSyncStartedAt ? Number(runtime.restoreSyncStartedAt) < tenMinutesAgo : true;
+  if (runtime.restoreSyncActive === true && isRestoreSyncStale) {
+    logger("Scheduled Sync: detected stale restoreSyncActive flag, resetting...");
+    await setRuntimeState({ restoreSyncActive: false }).catch(() => null);
+    runtime.restoreSyncActive = false;
+  }
+
+  if (runtime.rebuildActive === true || runtime.forceSyncActive === true || runtime.restoreSyncActive === true) {
+    logger("Scheduled Sync: skipped because a database rebuild, force sync, or authoritative restore is currently active.");
     return { sessions: 0, completions: 0, removed: 0, cached: 0, skipped: true };
   }
   await setRuntimeState({ lastCronExecution: Date.now() }).catch(() => null);

--- a/server/src/utils/embyClient.js
+++ b/server/src/utils/embyClient.js
@@ -335,6 +335,22 @@ export async function fetchEmbyEpisodes(config, parentId) {
   return data?.Items || [];
 }
 
+// Mark unplayed directly by native item Id, skipping the search/match step. Used by the
+// authoritative restore clear pass, which already has the Id from fetchEmbyWatchedItems.
+export async function markEmbyUnplayedById(config, itemId) {
+  requireEmbyConfig(config);
+  if (!itemId) return { platform: "emby", status: "not_found" };
+
+  const url = new URL(`${trimTrailingSlash(config.baseUrl)}/Users/${config.userId}/PlayedItems/${itemId}`);
+  url.searchParams.set("api_key", config.apiKey);
+
+  const response = await fetch(url, { method: "DELETE", headers: authHeaders(config) });
+  if (!response.ok) {
+    throw new Error(`Emby mark unplayed failed with status ${response.status} for item ${itemId}`);
+  }
+  return { platform: "emby", status: "fulfilled", itemId, httpStatus: response.status };
+}
+
 export async function fetchEmbyWatchedItems(config, { limit = 0 } = {}) {
   requireEmbyConfig(config);
   const baseUrl = trimTrailingSlash(config.baseUrl);

--- a/server/src/utils/jellyfinClient.js
+++ b/server/src/utils/jellyfinClient.js
@@ -351,6 +351,26 @@ export async function fetchJellyfinEpisodes(config, parentId) {
   return data?.Items || [];
 }
 
+// Mark unplayed directly by native item Id, skipping the search/match step. Used by the
+// authoritative restore clear pass, which already has the Id from fetchJellyfinWatchedItems.
+export async function markJellyfinUnplayedById(config, itemId) {
+  requireJellyfinConfig(config);
+  if (!itemId) return { platform: "jellyfin", status: "not_found" };
+
+  const url = new URL(`${trimTrailingSlash(config.baseUrl)}/Users/${config.userId}/PlayedItems/${itemId}`);
+  url.searchParams.set("api_key", jellyfinApiKey(config));
+
+  const response = await fetch(url, {
+    method: "DELETE",
+    headers: { ...authHeaders(config), "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  if (!response.ok) {
+    throw new Error(`Jellyfin mark unplayed failed with status ${response.status} for item ${itemId}`);
+  }
+  return { platform: "jellyfin", status: "fulfilled", itemId, httpStatus: response.status };
+}
+
 export async function fetchJellyfinWatchedItems(config, { limit = 0 } = {}) {
   requireJellyfinConfig(config);
   const apiKey = jellyfinApiKey(config);

--- a/server/src/utils/plexClient.js
+++ b/server/src/utils/plexClient.js
@@ -389,6 +389,26 @@ export async function setPlexProgress(config, media) {
   }
 }
 
+// Mark unplayed directly by ratingKey, skipping the search/match step. Used by the
+// authoritative restore clear pass, which already has the native ratingKey from
+// fetchPlexWatchedItems and doesn't need to re-resolve the item.
+export async function markPlexUnplayedByRatingKey(config, ratingKey) {
+  requirePlexConfig(config);
+  if (!ratingKey) return { platform: "plex", status: "not_found" };
+
+  const url = new URL(`${trimTrailingSlash(config.baseUrl)}/:/unscrobble`);
+  url.searchParams.set("key", String(ratingKey));
+  url.searchParams.set("identifier", "com.plexapp.plugins.library");
+  url.searchParams.set("X-Plex-Token", config.token);
+  await addConfiguredPlexAccountId(url, config);
+
+  const response = await fetch(url, { headers: { Accept: "application/json" } });
+  if (!response.ok) {
+    throw new Error(`Plex unscrobble failed with status ${response.status} for ratingKey ${ratingKey}`);
+  }
+  return { platform: "plex", status: "fulfilled", itemId: ratingKey, httpStatus: response.status };
+}
+
 export async function fetchPlexWatchedItems(config) {
   requirePlexConfig(config);
   const baseUrl = trimTrailingSlash(config.baseUrl);

--- a/server/src/utils/watchHistoryBackups.js
+++ b/server/src/utils/watchHistoryBackups.js
@@ -85,6 +85,15 @@ export function isCronSyncPaused() {
   return true;
 }
 
+// Stamp the restore watermark. The scheduled sync permanently skips any item whose
+// app-side play timestamp is <= lastRestoreAt, so this MUST be set *after* the
+// authoritative restore has finished pushing fresh state to the apps — otherwise the
+// pushes (stamped "now" by the apps) would be re-imported as watched-today.
+export function setLastRestoreAt(timestamp = Date.now()) {
+  saveRuntime({ lastRestoreAt: timestamp });
+  return { lastRestoreAt: timestamp };
+}
+
 // ---- Remote backup destinations --------------------------------------------
 
 function safeDestination(value = {}) {
@@ -473,7 +482,10 @@ export function restoreWatchHistoryBackup(filename, { mode = "merge", dryRun = f
     for (const row of document.data.playbackProgress) insertProgress.run(row);
   })();
   bumpDataVersion();
-  saveRuntime({ lastRestoreAt: Date.now(), lastRestore: { filename, ...summary } });
+  // NOTE: lastRestoreAt is intentionally NOT set here. The authoritative restore job
+  // (handleWatchBackups in index.js) stamps it via setLastRestoreAt() only *after* it has
+  // finished pushing the restored state to the connected apps. See setLastRestoreAt above.
+  saveRuntime({ lastRestore: { filename, ...summary } });
   return { ...summary, dryRun: false };
 }
 


### PR DESCRIPTION
## Problem

Restoring a backup is meant to make that backup the source of truth across all connected apps. Instead, restore was local-only and a cron job re-imported the apps' stale watchstates as if they'd been **watched today**. The only guard (`lastRestoreAt`) was set *before* any push and was missing from several import paths.

## Fix

Restore is now an authoritative, source-of-truth operation:

1. Locks down (`restoreSyncActive`) so cron + webhooks stop importing immediately.
2. Wipes local tables and restores from the backup (synchronous; returns **202**).
3. Background job clears + pushes the restored state to every app.
4. Stamps `lastRestoreAt` **after** the push (key fix) — so the pushes fall under the cron's pre-restore filter — then clears the flag.

### Backend
- New background reconcile job (streams a batched log into `runtime_state`; GET status reports `restoreSync.{active,log,result}`).
- `pushRestoredStateToApps` reuses `syncMediaPlaystate`/`syncMediaUnplayedPlaystate`; `clearAppWatchstates` ("full wipe" option) reuses `fetch*WatchedItems` + new direct by-id unmark helpers.
- `setLastRestoreAt` now owns the watermark (post-push) instead of `restoreWatchHistoryBackup`.
- Webhook handler ignores inbound events while a restore is active.
- Restore is replace-only; merge removed.

### Closed un-guarded import paths (`scheduled.js`)
- `runScheduledSync` bails while `restoreSyncActive` (+ 10-min stale reset).
- `lastRestoreAt` skip added to resume/continue-watching sync and to stale live-session completion.

### Frontend
- Clear-mode selector: **Reconcile tracked items** vs **Full wipe then push**.
- Restore progress terminal now polls the job status endpoint.

## Verification
Booted the app and ran the full path against the API: dry-run, then `reconcile` and `wipe` restores → 202 → background job pushed all playstate items → `lastRestoreAt` stamped after the push → flag cleared, no unhandled errors. Real user plays after a restore still record normally (they're after the watermark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)