### PR TITLE
Never re-date earlier-watched items to today; fix stuck/slow restore

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -609,20 +609,25 @@ function renderWatchBackups() {
        </div>`
     : "";
 
-  const remoteLoading = state.remoteBackupFilesLoading
-    ? `<div class="empty-log" style="padding: var(--space-2);"><span>Loading remote backups…</span></div>`
-    : "";
+  let remoteLoading = "";
+  if (state.remoteBackupFilesLoading) {
+    const destNames = Array.isArray(state.watchBackups?.destinations)
+      ? state.watchBackups.destinations.map((d) => d.label || d.type).filter(Boolean)
+      : [];
+    const destText = destNames.length ? ` (${destNames.map(escapeHtml).join(", ")})` : "";
+    remoteLoading = `<div class="remote-search-banner"><span class="remote-search-spinner"></span><span>Searching remote destinations${destText} for backups…</span></div>`;
+  }
 
   const clearMode = state.restoreClearMode || "reconcile";
   const clearModeSelector = `
-    <div class="restore-clear-mode backup-runtime" style="margin-bottom: var(--space-3); display: grid; gap: var(--space-2);">
-      <div style="font-weight: 600;">Restoring makes this backup the source of truth — it is pushed to every connected app. Choose how to clear the apps first:</div>
-      <label style="display: flex; gap: var(--space-2); align-items: flex-start; cursor: pointer;">
-        <input type="radio" name="restoreClearMode" value="reconcile" ${clearMode === "reconcile" ? "checked" : ""} data-restore-clear-mode style="margin-top: 3px;">
+    <div class="restore-clear-mode" style="margin-bottom: var(--space-3);">
+      <div class="restore-clear-intro">Restoring makes this backup the source of truth — it is pushed to every connected app. Choose how to clear the apps first:</div>
+      <label>
+        <input type="radio" name="restoreClearMode" value="reconcile" ${clearMode === "reconcile" ? "checked" : ""} data-restore-clear-mode>
         <span><b>Reconcile tracked items</b> — push only the items this backup knows about. Fast. Apps keep any extra watched items the backup never tracked.</span>
       </label>
-      <label style="display: flex; gap: var(--space-2); align-items: flex-start; cursor: pointer;">
-        <input type="radio" name="restoreClearMode" value="wipe" ${clearMode === "wipe" ? "checked" : ""} data-restore-clear-mode style="margin-top: 3px;">
+      <label>
+        <input type="radio" name="restoreClearMode" value="wipe" ${clearMode === "wipe" ? "checked" : ""} data-restore-clear-mode>
         <span><b>Full wipe then push</b> — mark every currently-watched item on each app as unwatched, then re-apply only the backup's watched set. Apps end up matching the backup exactly. Slower.</span>
       </label>
     </div>`;
@@ -644,7 +649,7 @@ function renderWatchBackups() {
         </button>
       </div>
     </article>
-  `).join("") : `<div class="empty-log"><b>No backups found</b><span>Backups will appear here once created or after remote destinations are configured.</span></div>`);
+  `).join("") : (state.remoteBackupFilesLoading ? "" : `<div class="empty-log"><b>No backups found</b><span>Backups will appear here once created or after remote destinations are configured.</span></div>`));
 }
 
 async function loadRemoteBackupsForRestoreTab() {
@@ -1129,11 +1134,13 @@ async function runAuthoritativeRestore(payload) {
 }
 
 // Poll the watch-backups status endpoint, appending new restore-job log lines to the terminal
-// until the job is no longer active. Returns the job result.
+// until the job is actually finished (restoreSync.active === false). A large restore can run a
+// long time, so we keep following it (high safety cap ~3h) instead of giving up early.
 async function pollRestoreProgress(terminal) {
   const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const MAX_TICKS = 5400; // ~3h at 2s
   let printed = 0;
-  for (let i = 0; i < 600; i++) {
+  for (let i = 0; i < MAX_TICKS; i++) {
     let data;
     try {
       const response = await fetch("/api/watch-backups", { headers: authHeaders(), cache: "no-store" });
@@ -1157,6 +1164,7 @@ async function pollRestoreProgress(terminal) {
     }
     await sleep(2000);
   }
+  if (terminal) terminal.textContent += "[Note] Still running — stopped following the log. Check the server logs for completion.\n";
   return null;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -893,9 +893,27 @@
                         <span>How to restore</span>
                       </div>
 
-                      <h4 style="margin: 0 0 var(--space-1); color: var(--text); font-size: 0.85rem;">Watch History Wipe / Restore</h4>
+                      <h4 style="margin: 0 0 var(--space-1); color: var(--text); font-size: 0.85rem;">What a restore does</h4>
+                      <p class="tool-accordion-desc" style="font-size: 0.8rem; margin-bottom: var(--space-2);">
+                        The selected backup becomes the single source of truth. Plembfin runs an authoritative restore:
+                      </p>
+                      <ol class="tool-accordion-desc" style="margin: 0 0 var(--space-3); padding-left: 1.2rem; font-size: 0.8rem; list-style: decimal;">
+                        <li>Wipes the local watch history, playstate and resume progress, and reloads them from the backup.</li>
+                        <li>Pushes that state out to every connected app (Plex, Emby, Jellyfin).</li>
+                        <li>Stamps a restore watermark so the background sync can never re-import the apps' state afterwards.</li>
+                      </ol>
                       <p class="tool-accordion-desc" style="font-size: 0.8rem; margin-bottom: var(--space-3);">
-                        Clears Plembfin's local database and replaces it with the selected backup. During restore, the cron sync is paused to prevent re-importing from connected apps. Once complete, all items are synced to Plex, Emby, and Jellyfin so Plembfin becomes the source of truth.
+                        While the restore is running, the cron sync and incoming webhooks are ignored, so nothing is written to watch history mid-restore. <b>Watch dates are always preserved</b> — an item already watched on an earlier date is never re-added as watched today.
+                      </p>
+
+                      <h4 style="margin: 0 0 var(--space-1); color: var(--text); font-size: 0.85rem;">Reconcile tracked items</h4>
+                      <p class="tool-accordion-desc" style="font-size: 0.8rem; margin-bottom: var(--space-3);">
+                        Pushes only the items the backup knows about. Fast. Any extra items the apps have marked watched but the backup never tracked are left untouched. Choose this for a normal point-in-time restore.
+                      </p>
+
+                      <h4 style="margin: 0 0 var(--space-1); color: var(--text); font-size: 0.85rem;">Full wipe then push</h4>
+                      <p class="tool-accordion-desc" style="font-size: 0.8rem; margin-bottom: var(--space-3);">
+                        First marks every currently-watched item on each app as unwatched, then re-applies only the backup's watched set, so the apps end up matching the backup exactly. Slower (it touches every watched item on every app). Choose this when the apps contain watched state you want removed.
                       </p>
 
                       <h4 style="margin: 0 0 var(--space-1); color: var(--text); font-size: 0.85rem;">Restore onto New Instance</h4>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1711,6 +1711,86 @@ details[open] .tool-accordion-chevron::before {
   color: var(--red);
 }
 
+/* Restore clear-mode selector: stacked rows, normal case (NOT the 3-column uppercase
+   .backup-runtime grid). */
+.restore-clear-mode {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-3);
+}
+
+.restore-clear-mode .restore-clear-intro {
+  font-weight: 600;
+  color: var(--text);
+  font-size: 0.85rem;
+}
+
+.restore-clear-mode label {
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-start;
+  cursor: pointer;
+  padding: var(--space-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.restore-clear-mode label:hover {
+  border-color: var(--line-strong);
+}
+
+.restore-clear-mode input[type="radio"] {
+  margin-top: 3px;
+  flex: 0 0 auto;
+}
+
+.restore-clear-mode label span {
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--muted);
+  text-transform: none;
+  font-weight: 400;
+  letter-spacing: normal;
+}
+
+.restore-clear-mode label span b {
+  color: var(--text);
+  font-weight: 700;
+}
+
+/* Prominent "searching remote destinations" banner on the restore tab. */
+.remote-search-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius);
+  background: rgba(120, 170, 255, 0.08);
+  font-size: 0.82rem;
+  color: var(--text);
+}
+
+.remote-search-banner .remote-search-spinner {
+  width: 0.9rem;
+  height: 0.9rem;
+  border: 2px solid var(--line-strong);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: remote-search-spin 0.8s linear infinite;
+  flex: 0 0 auto;
+}
+
+@keyframes remote-search-spin {
+  to { transform: rotate(360deg); }
+}
+
 .watch-backup-list {
   display: grid;
   gap: var(--space-2);
@@ -4704,6 +4784,7 @@ h1 {
 }
 
 .sidebar-sub-menu .settings-tab,
+.sidebar-sub-menu .backups-sub-tab,
 .sidebar-sub-menu .help-menu-item {
   width: 100%;
   min-height: 1.85rem;
@@ -4723,6 +4804,7 @@ h1 {
 }
 
 .sidebar-sub-menu .settings-tab:hover,
+.sidebar-sub-menu .backups-sub-tab:hover,
 .sidebar-sub-menu .help-menu-item:hover {
   border-color: var(--line-strong);
   color: var(--text);
@@ -4730,6 +4812,7 @@ h1 {
 }
 
 .sidebar-sub-menu .settings-tab.active,
+.sidebar-sub-menu .backups-sub-tab.active,
 .sidebar-sub-menu .help-menu-item.active {
   border-color: #315b86;
   background: #172232;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -631,6 +631,36 @@ async function exchangeDropboxCode(destination, code) {
 // Small forward cushion so an app-recorded "viewedAt" stamped a moment after our push
 // can't land just past lastRestoreAt and get re-imported. See setLastRestoreAt().
 const RESTORE_SKEW_BUFFER_MS = 5000;
+// How many items the restore push/clear processes at once, and the per-item timeout so a single
+// hung app call can't stall the whole job.
+const RESTORE_PUSH_CONCURRENCY = 8;
+const RESTORE_ITEM_TIMEOUT_MS = 30000;
+
+function withTimeout(promise, ms, label) {
+  const p = Promise.resolve(promise);
+  // If the timeout wins the race, the underlying promise may still reject later with nobody
+  // awaiting it — absorb that so it doesn't surface as an unhandledRejection.
+  p.catch(() => {});
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms${label ? `: ${label}` : ""}`)), ms);
+  });
+  return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
+}
+
+// Run `worker(item)` over `items` with at most `limit` in flight. The worker is expected to handle
+// (count) its own errors; this resolves once every item has been processed.
+async function runWithConcurrency(items, limit, worker) {
+  let index = 0;
+  const runnerCount = Math.max(1, Math.min(limit, items.length));
+  const runners = Array.from({ length: runnerCount }, async () => {
+    while (index < items.length) {
+      const current = index++;
+      await worker(items[current], current);
+    }
+  });
+  await Promise.all(runners);
+}
 
 // Batched runtime-log writer (mirrors the Force-Sync pattern): collect lines in memory and
 // flush to runtime_state every `intervalMs` so we don't write per line.
@@ -683,20 +713,20 @@ function mediaFromPlaystateRow(row) {
 async function pushRestoredStateToApps(config, logLine) {
   const loopStore = createLoopStore();
   const rows = requireDb().prepare("SELECT * FROM playstate").all();
-  logLine(`Pushing ${rows.length} restored item(s) to connected apps...`);
+  logLine(`Pushing ${rows.length} restored item(s) to connected apps (concurrency ${RESTORE_PUSH_CONCURRENCY})...`);
   let done = 0;
   let watched = 0;
   let unwatched = 0;
   let failed = 0;
-  for (const row of rows) {
+  await runWithConcurrency(rows, RESTORE_PUSH_CONCURRENCY, async (row) => {
     const media = mediaFromPlaystateRow(row);
     const isWatched = String(row.state || "watched").toLowerCase() !== "unwatched";
     try {
       if (isWatched) {
-        await syncMediaPlaystate(media, config, loopStore);
+        await withTimeout(syncMediaPlaystate(media, config, loopStore), RESTORE_ITEM_TIMEOUT_MS, media.title);
         watched++;
       } else {
-        await syncMediaUnplayedPlaystate(media, config, loopStore);
+        await withTimeout(syncMediaUnplayedPlaystate(media, config, loopStore), RESTORE_ITEM_TIMEOUT_MS, media.title);
         unwatched++;
       }
     } catch (error) {
@@ -707,7 +737,7 @@ async function pushRestoredStateToApps(config, logLine) {
     if (done % 25 === 0 || done === rows.length) {
       logLine(`  Pushed ${done}/${rows.length} (watched ${watched}, unwatched ${unwatched}, failed ${failed})`);
     }
-  }
+  });
   return { total: rows.length, watched, unwatched, failed };
 }
 
@@ -720,18 +750,28 @@ async function clearAppWatchstates(config, logLine) {
   const embyActive = !config?.emby?.disabled && Boolean(config?.emby?.baseUrl && config?.emby?.apiKey && config?.emby?.userId);
   const jellyfinActive = !config?.jellyfin?.disabled && Boolean(config?.jellyfin?.baseUrl && config?.jellyfin?.apiKey && config?.jellyfin?.userId);
 
+  // Mark one platform's watched items unplayed, in parallel with a per-item timeout.
+  const clearPlatform = async (items, getId, unmark) => {
+    let cleared = 0;
+    let failed = 0;
+    await runWithConcurrency(items, RESTORE_PUSH_CONCURRENCY, async (item) => {
+      try {
+        await withTimeout(unmark(getId(item)), RESTORE_ITEM_TIMEOUT_MS);
+        cleared++;
+      } catch (error) {
+        failed++;
+      }
+    });
+    return { cleared, failed };
+  };
+
   if (plexActive) {
     try {
       const items = await fetchPlexWatchedItems(config.plex);
       logLine(`Clearing ${items.length} watched item(s) on Plex...`);
-      for (const item of items) {
-        try {
-          await markPlexUnplayedByRatingKey(config.plex, item.ratingKey || item.key);
-          summary.plex++;
-        } catch (error) {
-          summary.failed++;
-        }
-      }
+      const r = await clearPlatform(items, (i) => i.ratingKey || i.key, (id) => markPlexUnplayedByRatingKey(config.plex, id));
+      summary.plex = r.cleared;
+      summary.failed += r.failed;
     } catch (error) {
       logLine(`  ! Plex clear failed: ${error.message}`);
     }
@@ -740,14 +780,9 @@ async function clearAppWatchstates(config, logLine) {
     try {
       const items = await fetchEmbyWatchedItems(config.emby);
       logLine(`Clearing ${items.length} watched item(s) on Emby...`);
-      for (const item of items) {
-        try {
-          await markEmbyUnplayedById(config.emby, item.Id);
-          summary.emby++;
-        } catch (error) {
-          summary.failed++;
-        }
-      }
+      const r = await clearPlatform(items, (i) => i.Id, (id) => markEmbyUnplayedById(config.emby, id));
+      summary.emby = r.cleared;
+      summary.failed += r.failed;
     } catch (error) {
       logLine(`  ! Emby clear failed: ${error.message}`);
     }
@@ -756,14 +791,9 @@ async function clearAppWatchstates(config, logLine) {
     try {
       const items = await fetchJellyfinWatchedItems(config.jellyfin);
       logLine(`Clearing ${items.length} watched item(s) on Jellyfin...`);
-      for (const item of items) {
-        try {
-          await markJellyfinUnplayedById(config.jellyfin, item.Id);
-          summary.jellyfin++;
-        } catch (error) {
-          summary.failed++;
-        }
-      }
+      const r = await clearPlatform(items, (i) => i.Id, (id) => markJellyfinUnplayedById(config.jellyfin, id));
+      summary.jellyfin = r.cleared;
+      summary.failed += r.failed;
     } catch (error) {
       logLine(`  ! Jellyfin clear failed: ${error.message}`);
     }
@@ -776,6 +806,14 @@ async function clearAppWatchstates(config, logLine) {
 // so the pushes themselves fall under the cron's pre-restore filter) and clears the active flag.
 async function runRestoreReconcileJob(clearMode) {
   const { log, stop } = createBatchedRuntimeLogger("restoreSyncLog");
+  // Keep the restore guard's heartbeat fresh for the entire job so the cron never treats a
+  // long-but-alive restore as stale and un-blocks itself mid-push. Fires independently of where
+  // the job is (even inside a long library fetch).
+  await setRuntimeState({ restoreSyncHeartbeat: Date.now() }).catch(() => null);
+  const heartbeat = setInterval(() => {
+    setRuntimeState({ restoreSyncHeartbeat: Date.now() }).catch(() => null);
+  }, 30000);
+  if (typeof heartbeat.unref === "function") heartbeat.unref();
   let result;
   try {
     const config = await loadMediaConfig();
@@ -793,6 +831,7 @@ async function runRestoreReconcileJob(clearMode) {
     log(`ERROR: Restore reconcile failed: ${error.message}`);
     result = { success: false, error: error.message };
   } finally {
+    clearInterval(heartbeat);
     // Always advance the watermark: after a successful DB restore the local DB IS the backup,
     // so the cron should ignore any app history at/before now regardless of push outcome.
     const stampedAt = Date.now() + RESTORE_SKEW_BUFFER_MS;
@@ -800,6 +839,8 @@ async function runRestoreReconcileJob(clearMode) {
     log(`Stamped lastRestoreAt = ${new Date(stampedAt).toISOString()}; cron will skip app history up to this point.`);
     log("✓ Authoritative restore complete.");
     await stop();
+    // Clear the active flag LAST (after lastRestoreAt is stamped) so the first allowed cron tick
+    // already sees the watermark.
     await setRuntimeState({ restoreSyncActive: false, restoreSyncResult: result || { success: false } }).catch(() => null);
   }
   return result;
@@ -818,6 +859,7 @@ async function startAuthoritativeRestore(filename, clearMode) {
   await setRuntimeState({
     restoreSyncActive: true,
     restoreSyncStartedAt: Date.now(),
+    restoreSyncHeartbeat: Date.now(),
     restoreSyncResult: null,
     restoreSyncLog: [`Authoritative restore started (${clearMode}) from ${filename}...`],
   });

--- a/server/src/scheduled.js
+++ b/server/src/scheduled.js
@@ -413,6 +413,13 @@ async function processCompletedSession(row, config, loopStore) {
     return null;
   }
 
+  // Invariant: never re-date an already-watched item to today. If plembfin already has this title
+  // marked watched, don't post a fresh Date.now() record from the live tracker.
+  const knownPlaystate = await getPlaystateForMedia(requireDb(), media).catch(() => null);
+  if (knownPlaystate?.state === "watched") {
+    return null;
+  }
+
   await markLiveTrackingComplete(requireDb(), row.session_id, Date.now());
 
   const watchRecord = mediaToWatchRecord(
@@ -766,6 +773,14 @@ async function syncRecentlyWatchedFromPlex(config, loopStore, logger = console.l
       const existing = await findExistingWatch(key, watchedAt);
 
       if (!existing) {
+        // Invariant: never re-date an already-watched item to today. If plembfin already has it
+        // marked watched, preserve the earlier date and skip — the app reporting it watched (e.g.
+        // because a restore just scrobbled it) must not create a today-dated record.
+        const knownPlaystate = await getPlaystateForMedia(requireDb(), media).catch(() => null);
+        if (knownPlaystate?.state === "watched") {
+          logger(`Plex: ${media.title} already watched; preserving earlier date (no today-dated record)`);
+          continue;
+        }
         const lastRestoreAt = Number(loadWatchBackupRuntime().lastRestoreAt || 0);
         if (lastRestoreAt && new Date(watchedAt).getTime() <= lastRestoreAt) {
           logger(`Plex: skipped pre-restore item (played ${watchedAt}): ${media.title}`);
@@ -854,6 +869,12 @@ async function syncRecentlyWatchedFromEmby(config, loopStore, logger = console.l
       const existing = await findWatchedByAnyMediaKey(media);
 
       if (!existing) {
+        // Invariant: never re-date an already-watched item to today (see Plex path above).
+        const knownPlaystate = await getPlaystateForMedia(requireDb(), media).catch(() => null);
+        if (knownPlaystate?.state === "watched") {
+          logger(`Emby: ${media.title} already watched; preserving earlier date (no today-dated record)`);
+          continue;
+        }
         const lastRestoreAt = Number(loadWatchBackupRuntime().lastRestoreAt || 0);
         if (lastRestoreAt && new Date(watchedAt).getTime() <= lastRestoreAt) {
           logger(`Emby: skipped pre-restore item (played ${watchedAt}): ${media.title}`);
@@ -941,6 +962,12 @@ async function syncRecentlyWatchedFromJellyfin(config, loopStore, logger = conso
       const existing = await findWatchedByAnyMediaKey(media);
 
       if (!existing) {
+        // Invariant: never re-date an already-watched item to today (see Plex path above).
+        const knownPlaystate = await getPlaystateForMedia(requireDb(), media).catch(() => null);
+        if (knownPlaystate?.state === "watched") {
+          logger(`Jellyfin: ${media.title} already watched; preserving earlier date (no today-dated record)`);
+          continue;
+        }
         const lastRestoreAt = Number(loadWatchBackupRuntime().lastRestoreAt || 0);
         if (lastRestoreAt && new Date(watchedAt).getTime() <= lastRestoreAt) {
           logger(`Jellyfin: skipped pre-restore item (played ${watchedAt}): ${media.title}`);
@@ -1115,11 +1142,16 @@ export async function runScheduledSync(logger = console.log) {
     runtime.forceSyncActive = false;
   }
 
-  // Reset a restore-reconcile flag that got stuck (e.g. process crashed mid-job) so the cron
-  // isn't blocked forever.
-  const isRestoreSyncStale = runtime.restoreSyncStartedAt ? Number(runtime.restoreSyncStartedAt) < tenMinutesAgo : true;
+  // Only reset the restore-reconcile flag if the job's heartbeat has gone cold (i.e. the process
+  // actually died mid-job). A long-but-alive restore refreshes restoreSyncHeartbeat continuously,
+  // so it is NEVER un-blocked here — that prevents the cron from running mid-push and re-importing
+  // freshly-pushed items as watched-today. (Do NOT use restoreSyncStartedAt: a big push runs far
+  // longer than any fixed timeout.)
+  const RESTORE_HEARTBEAT_STALE_MS = 3 * 60 * 1000;
+  const restoreHeartbeat = Number(runtime.restoreSyncHeartbeat || runtime.restoreSyncStartedAt || 0);
+  const isRestoreSyncStale = !restoreHeartbeat || restoreHeartbeat < Date.now() - RESTORE_HEARTBEAT_STALE_MS;
   if (runtime.restoreSyncActive === true && isRestoreSyncStale) {
-    logger("Scheduled Sync: detected stale restoreSyncActive flag, resetting...");
+    logger("Scheduled Sync: restore heartbeat is cold (>3m); resetting stale restoreSyncActive flag...");
     await setRuntimeState({ restoreSyncActive: false }).catch(() => null);
     runtime.restoreSyncActive = false;
   }


### PR DESCRIPTION
## The invariant
**An item watched on an earlier date is never added to watch history as played today.** Every scheduled watched-import path (`syncRecentlyWatchedFromPlex/Emby/Jellyfin` + `processCompletedSession`) now skips any item already marked watched in playstate, preserving the earlier date. Timing-independent: every item a restore pushes is already watched in the restored playstate, so the cron physically cannot re-date it. New first-time watches still import with the app's real date.

## The bug that broke the previous fix
The cron's 10-minute "stale `restoreSyncActive`" reset force-unblocked the cron **mid-push** (a large push runs far longer than 10 min), letting it re-import freshly-pushed items as watched-today before `lastRestoreAt` was stamped. Replaced with a **heartbeat** the job refreshes every 30s; the cron only resets the flag if the heartbeat goes cold (>3 min = process actually died).

## Stuck / slow
- `pushRestoredStateToApps` and `clearAppWatchstates` now run through a bounded concurrency pool (8) with a 30s per-item timeout (and absorb late rejections), so one hung app call can't stall the job.
- Frontend poller follows the job to real completion instead of giving up at 20 minutes.

## UI polish
- `.backups-sub-tab` (Settings/Restore) styled like the rest of the sidebar menu.
- Clear-mode selector stacks vertically in normal case (dropped the reused `.backup-runtime` grid+uppercase).
- Prominent "Searching remote destinations…" banner while remote backups load.
- Expanded Restore Guide with a full per-mode breakdown.

## Verification
Server boots clean; `reconcile` and `wipe` restores return 202 → background job completes (concurrency 8), heartbeat written, `lastRestoreAt` stamped after the push, no unhandled errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)