### PR TITLE
🎨 Palette: Add ARIA states to sync settings accordions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1363,7 +1363,7 @@
                 <div class="settings-row" data-sub-panel="sync-issues">
                   <div class="settings-row-main">
                     <section class="glass-panel p-section sync-panel">
-                      <button id="syncIssuesToggle" class="section-heading sync-heading" type="button" style="background: none; border: none; cursor: pointer; width: 100%; text-align: left; padding: 0;">
+                      <button id="syncIssuesToggle" class="section-heading sync-heading" type="button" aria-expanded="true" aria-controls="syncIssuesContent" style="background: none; border: none; cursor: pointer; width: 100%; text-align: left; padding: 0;">
                         <div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
                           <div style="display: flex; align-items: center; gap: var(--space-2);">
                             <p style="margin: 0;">Sync Issues</p>
@@ -1422,7 +1422,7 @@
                 <div class="settings-row hidden" data-sub-panel="sync-history">
                   <div class="settings-row-main">
                     <section class="glass-panel p-section sync-panel">
-                      <button id="syncHistoryToggle" class="section-heading sync-heading" type="button" style="background: none; border: none; cursor: pointer; width: 100%; text-align: left; padding: 0;">
+                      <button id="syncHistoryToggle" class="section-heading sync-heading" type="button" aria-expanded="true" aria-controls="syncHistoryContent" style="background: none; border: none; cursor: pointer; width: 100%; text-align: left; padding: 0;">
                         <div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
                           <div style="display: flex; align-items: center; gap: var(--space-2);">
                             <p style="margin: 0;">Sync History</p>
@@ -1468,7 +1468,7 @@
                 <div class="settings-row hidden" data-sub-panel="sync-tools">
                   <div class="settings-row-main">
                     <section class="glass-panel p-section sync-panel">
-                      <button id="syncToolsToggle" class="section-heading sync-heading" type="button" style="background: none; border: none; cursor: pointer; width: 100%; text-align: left; padding: 0;">
+                      <button id="syncToolsToggle" class="section-heading sync-heading" type="button" aria-expanded="true" aria-controls="syncToolsContent" style="background: none; border: none; cursor: pointer; width: 100%; text-align: left; padding: 0;">
                         <div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
                           <p style="margin: 0;">Sync Tools</p>
                           <span id="syncToolsToggleIcon" style="font-size: 1.2rem;">▼</span>

--- a/public/modules/app-events.js
+++ b/public/modules/app-events.js
@@ -1344,9 +1344,11 @@ function attachEvents() {
       if (isHidden) {
         elements.syncIssuesContent.classList.remove("hidden");
         elements.syncIssuesToggleIcon.textContent = "▼";
+        elements.syncIssuesToggle.setAttribute("aria-expanded", "true");
       } else {
         elements.syncIssuesContent.classList.add("hidden");
         elements.syncIssuesToggleIcon.textContent = "▶";
+        elements.syncIssuesToggle.setAttribute("aria-expanded", "false");
       }
     });
   }
@@ -1358,9 +1360,11 @@ function attachEvents() {
       if (isHidden) {
         elements.syncHistoryContent.classList.remove("hidden");
         elements.syncHistoryToggleIcon.textContent = "▼";
+        elements.syncHistoryToggle.setAttribute("aria-expanded", "true");
       } else {
         elements.syncHistoryContent.classList.add("hidden");
         elements.syncHistoryToggleIcon.textContent = "▶";
+        elements.syncHistoryToggle.setAttribute("aria-expanded", "false");
       }
     });
   }
@@ -1372,9 +1376,11 @@ function attachEvents() {
       if (isHidden) {
         elements.syncToolsContent.classList.remove("hidden");
         elements.syncToolsToggleIcon.textContent = "▼";
+        elements.syncToolsToggle.setAttribute("aria-expanded", "true");
       } else {
         elements.syncToolsContent.classList.add("hidden");
         elements.syncToolsToggleIcon.textContent = "▶";
+        elements.syncToolsToggle.setAttribute("aria-expanded", "false");
       }
     });
   }


### PR DESCRIPTION
💡 **What:** Added `aria-expanded` and `aria-controls` attributes to the custom accordion toggle buttons in the Sync settings (`syncIssuesToggle`, `syncHistoryToggle`, and `syncToolsToggle`). Updated the click event handlers in `app-events.js` to dynamically toggle the `aria-expanded` state between `true` and `false`.
🎯 **Why:** Custom accordions lack native semantic bindings, meaning screen reader users wouldn't know the state of the collapsible content (expanded or collapsed). This change makes the sync settings panels fully accessible.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers can now correctly announce whether the sync sections are expanded or collapsed and relate the toggle button to the content it controls.

---
*PR created automatically by Jules for task [8538036966290337293](https://jules.google.com/task/8538036966290337293) started by @Lasikiewicz*