### PR TITLE
fix: resolve open code scanning alerts

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -42,4 +42,3 @@ jobs:
           languages: javascript
           config-file: ./.github/codeql/codeql-config.yml
       - uses: github/codeql-action/analyze@v4
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "busboy": "^1.6.0",
         "cookie-parser": "^1.4.7",
         "express": "^5.2.1",
-        "express-rate-limit": "^8.5.2",
+        "express-rate-limit": "^8.6.0",
         "morgan": "^1.11.0",
         "rotating-file-stream": "^3.2.9",
         "sharp": "^0.35.2",
@@ -993,11 +993,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -1009,6 +1010,29 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/express/node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "busboy": "^1.6.0",
     "cookie-parser": "^1.4.7",
     "express": "^5.2.1",
-    "express-rate-limit": "^8.5.2",
+    "express-rate-limit": "^8.6.0",
     "morgan": "^1.11.0",
     "rotating-file-stream": "^3.2.9",
     "sharp": "^0.35.2",

--- a/public/modules/dashboard.js
+++ b/public/modules/dashboard.js
@@ -1,7 +1,7 @@
 import { buildAuthHeaders } from "./auth.js";
 import { state, elements } from "./state.js";
 import { escapeHtml, escapeAttribute, slug, showTitleFrom, showName, movieHref, sourceBadgeHtml, formatDate, resolveEpisodeTitle, episodeCode, normalizePlatformSource, platformBadge, sourceClass, platformIconUrl, computeProgress } from "./utils.js";
-import { posterMarkup, hydratePosters, lookupPosterUrl, bindPosterImageErrorHandler, tmdbPoster } from "./images.js";
+import { posterMarkup, hydratePosters, lookupPosterUrl, bindPosterImageErrorHandler, safePosterElementUrl, tmdbPoster } from "./images.js";
 
 const PART_WATCHED_DASHBOARD_LIMIT = 30;
 const EXPLORER_PAGE_SIZE = 240;
@@ -279,12 +279,13 @@ export function observeDashboardPosters() {
         if (!posterId || state.posterLookupCache.has(posterId)) return;
 
         const posterUrl = await lookupPosterUrl(posterId);
-        if (!posterUrl || !fallback.isConnected || !fallback.classList.contains("poster-fallback")) return;
+        const safeUrl = safePosterElementUrl(posterUrl);
+        if (!safeUrl || !fallback.isConnected || !fallback.classList.contains("poster-fallback")) return;
 
         const image = document.createElement("img");
         image.className = fallback.className.replace(/\bposter-fallback\b/g, "").trim() || fallback.className;
         bindPosterImageErrorHandler(image);
-        image.src = posterUrl;
+        image.src = safeUrl;
         image.alt = `${fallback.getAttribute("aria-label") || "Media poster"}`;
         image.loading = "lazy";
         image.decoding = "async";

--- a/public/modules/images.js
+++ b/public/modules/images.js
@@ -23,7 +23,22 @@ export function compactPosterUrl(value) {
   if (isCachedStorageImageUrl(raw)) return raw;
   const url = safeImageUrl(raw);
   if (!url) return "";
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" || parsed.hostname.toLowerCase() !== "image.tmdb.org") return "";
+  } catch (error) {
+    return "";
+  }
   return url.replace(/(https:\/\/image\.tmdb\.org\/t\/p\/)original\//i, `$1${TMDB_POSTER_SIZE}/`);
+}
+
+// Poster responses are untrusted data. Keep the DOM image sink limited to
+// local cached media and TMDB artwork, which are the only sources this module
+// is expected to hydrate.
+export function safePosterElementUrl(value) {
+  const raw = String(value || "").trim();
+  if (isCachedStorageImageUrl(raw)) return raw;
+  return compactPosterUrl(raw);
 }
 
 function persistentPosterCacheKey() {
@@ -266,12 +281,13 @@ export async function hydratePosterFallbacks(container = document.body) {
     if (!posterId || state.posterLookupCache.has(posterId)) return;
 
     const posterUrl = await lookupPosterUrl(posterId);
-    if (!posterUrl || !fallback.isConnected || !fallback.classList.contains("poster-fallback")) return;
+    const safeUrl = safePosterElementUrl(posterUrl);
+    if (!safeUrl || !fallback.isConnected || !fallback.classList.contains("poster-fallback")) return;
 
     const image = document.createElement("img");
     image.className = fallback.className.replace(/\bposter-fallback\b/g, "").trim() || fallback.className;
     bindPosterImageErrorHandler(image);
-    image.src = posterUrl;
+    image.src = safeUrl;
     image.alt = `${fallback.getAttribute("aria-label") || "Media poster"}`;
     image.loading = "lazy";
     image.decoding = "async";
@@ -303,8 +319,9 @@ export function bindPosterImageErrorHandler(image) {
     image.dataset.posterFallbackAttempted = "1";
     const brokenUrl = image.currentSrc || image.src;
     const fallbackUrl = await lookupPosterUrl(posterId, { fallback: true });
-    if (fallbackUrl && fallbackUrl !== brokenUrl && image.isConnected) {
-      image.src = fallbackUrl;
+    const safeFallbackUrl = safePosterElementUrl(fallbackUrl);
+    if (safeFallbackUrl && safeFallbackUrl !== brokenUrl && image.isConnected) {
+      image.src = safeFallbackUrl;
       return;
     }
 

--- a/server/src/appConfig.js
+++ b/server/src/appConfig.js
@@ -116,19 +116,16 @@ function logSecuritySummary() {
     for (const w of warnings) console.warn(`   • ${w}`);
   }
   if (generated.length > 0) {
-    console.log(`[security] Auto-generated secrets: ${generated.join(", ")} (persisted in data/config.json)`);
+    console.log("[security] Auto-generated secrets are persisted in data/config.json.");
   }
   if (pinned.length > 0) {
-    console.log(`[security] Pinned secrets from env: ${pinned.join(", ")}`);
+    console.log("[security] Pinned secrets were loaded from the environment.");
   }
   if (config.authManagedInApp && (process.env.ADMIN_USERNAME || process.env.ADMIN_PASSWORD)) {
     console.warn("[security] Admin credentials are managed in-app; ADMIN_USERNAME/ADMIN_PASSWORD environment variables are ignored (remove authManagedInApp from data/config.json to restore env control).");
   }
   if (generatedInitialPassword) {
-    console.warn("⚠️  Generated initial admin credentials (shown once — this password is not stored anywhere in plaintext):");
-    console.warn(`   • Username: ${config.username}`);
-    console.warn(`   • Password: ${generatedInitialPassword}`);
-    console.warn("   Change this immediately in Settings → General.");
+    console.warn("⚠️  An initial admin password was generated. Set ADMIN_PASSWORD before first start or use the in-app recovery flow.");
   }
 }
 


### PR DESCRIPTION
Resolves all seven open CodeQL alerts by validating hydrated poster URLs, removing secret-bearing startup diagnostics, and applying the reviewed dependency updates from PRs #14 and #15.\n\nValidation: npm test (104 passed), npm run build, npm ci --dry-run --ignore-scripts --offline.