### PR TITLE
fix: complete movie watch history editing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plembfin",
-  "version": "0.5.38",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plembfin",
-      "version": "0.5.38",
+      "version": "0.6.0",
       "dependencies": {
         "better-sqlite3": "^12.11.1",
         "busboy": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plembfin",
-  "version": "0.5.38",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "server/server.js",

--- a/public/modules/media-detail-movie.js
+++ b/public/modules/media-detail-movie.js
@@ -97,6 +97,15 @@ export async function fetchWatchedMovieByTmdb(tmdbId, title) {
 }
 
 export async function renderMovieImmersiveModalContent(movie) {
+  // Route state can contain the lightweight latest-play record rather than the
+  // server's collapsed movie record. Rehydrate before the first paint so every
+  // detail entry point shows the same complete watch history.
+  if (movie && (!Array.isArray(movie.playHistory) || movie.playHistory.length < 2)) {
+    const fullMovie = await fetchWatchedMovieByTmdb(movie.tmdb_id, movie.title);
+    if (fullMovie && Array.isArray(fullMovie.playHistory) && fullMovie.playHistory.length > (movie.playHistory?.length || 0)) {
+      movie = fullMovie;
+    }
+  }
   // Half of a two-token handshake with media-detail-show.js — see the
   // bumpMediaRenderToken doc comment in media-detail-context.js before changing this.
   const renderToken = bumpMediaRenderToken();

--- a/public/modules/media-detail.js
+++ b/public/modules/media-detail.js
@@ -82,7 +82,13 @@ async function fetchMovieBySlugOrId(value) {
   }
 }
 export async function resolveMovieBySlugOrId(value) {
-  return movieBySlugOrId(value) || fetchMovieBySlugOrId(value);
+  const key = decodeURIComponent(String(value || ""));
+  // Preserve direct watch-history URLs, including legacy stats links. Slug
+  // routes must resolve through /api/movies so the page receives the server's
+  // deduplicated record with the complete playHistory array.
+  const directRecord = movieById(key);
+  if (directRecord) return directRecord;
+  return await fetchMovieBySlugOrId(value) || movieBySlugOrId(value);
 }
 export function nowPlayingHref(session = {}) {
   const mediaType = session.mediaType || (session.season != null || session.episode != null ? "tv" : "movie");

--- a/public/modules/stats.js
+++ b/public/modules/stats.js
@@ -1,6 +1,6 @@
 import { buildAuthHeaders } from "./auth.js";
 import { state, elements } from "./state.js";
-import { escapeHtml, escapeAttribute, platformName, formatNumber, formatDate, shortMonthLabel } from "./utils.js";
+import { escapeHtml, escapeAttribute, platformName, formatNumber, formatDate, shortMonthLabel, movieHref } from "./utils.js";
 import { posterMarkup, hydratePosterFallbacks } from "./images.js";
 
 let _cb = {};
@@ -179,7 +179,7 @@ export function statsIntroCards(report = selectedStatsReport(), periodLabel = "A
 
 function statsMediaHref(item = {}) {
   const title = item.title || "unknown";
-  if (item.type === "movie") return `/movie/${encodeURIComponent(item.id || _cb.slug?.(title) || title)}`;
+  if (item.type === "movie") return movieHref({ title });
   return `/tvshow/${encodeURIComponent(_cb.slug?.(title) || title)}`;
 }
 

--- a/server/src/utils/dataRepo.js
+++ b/server/src/utils/dataRepo.js
@@ -493,7 +493,7 @@ function createStatsPeriod(period, label) {
 }
 
 function statsMovieKey(row = {}) {
-  return row.imdb_id || row.tmdb_id || row.tvdb_id || canonicalTitleKey(row.title) || row.title || "unknown-movie";
+  return row._statsMovieKey || row.imdb_id || row.tmdb_id || row.tvdb_id || canonicalTitleKey(row.title) || row.title || "unknown-movie";
 }
 
 function statsShowKey(row = {}) {
@@ -569,6 +569,64 @@ function addRowToStatsPeriod(period, row = {}) {
     bumpStatsMedia(period.showMap, key, item);
     bumpStatsMedia(period.mediaMap, key, item);
   }
+}
+
+// Stats must use the same identity rule as the movie list: rows with any shared
+// provider ID belong to one film, and title-only rows join that film only when
+// the title has exactly one provider-ID cluster. This prevents imported plays
+// and initial-sync plays for the same film from becoming separate leaderboard
+// entries, while keeping same-title remakes separate when their IDs differ.
+function buildStatsMovieKeys(rows = []) {
+  const movieRows = rows.filter((row) => row.media_type === "movie");
+  const parent = new Map();
+  const find = (value) => {
+    while (parent.get(value) !== value) {
+      parent.set(value, parent.get(parent.get(value)));
+      value = parent.get(value);
+    }
+    return value;
+  };
+  const ensure = (value) => { if (!parent.has(value)) parent.set(value, value); };
+  const union = (a, b) => {
+    const left = find(a);
+    const right = find(b);
+    if (left !== right) parent.set(left, right);
+  };
+  const idNodesFor = (row) => [
+    cleanString(row.imdb_id) ? `imdb:${cleanString(row.imdb_id)}` : "",
+    cleanString(row.tmdb_id) ? `tmdb:${cleanString(row.tmdb_id)}` : "",
+    cleanString(row.tvdb_id) ? `tvdb:${cleanString(row.tvdb_id)}` : "",
+  ].filter(Boolean);
+
+  for (const row of movieRows) {
+    const nodes = idNodesFor(row);
+    nodes.forEach(ensure);
+    for (let index = 1; index < nodes.length; index += 1) union(nodes[0], nodes[index]);
+  }
+
+  const titleClusters = new Map();
+  for (const row of movieRows) {
+    const nodes = idNodesFor(row);
+    if (!nodes.length) continue;
+    const clusterKey = find(nodes[0]);
+    const titleKey = canonicalTitleKey(row.title);
+    if (!titleClusters.has(titleKey)) titleClusters.set(titleKey, new Set());
+    titleClusters.get(titleKey).add(clusterKey);
+  }
+
+  const keys = new Map();
+  for (const row of movieRows) {
+    const nodes = idNodesFor(row);
+    if (nodes.length) {
+      keys.set(row, find(nodes[0]));
+      continue;
+    }
+    const titleKey = canonicalTitleKey(row.title);
+    const matches = titleClusters.get(titleKey);
+    const clusterKey = matches?.size === 1 ? [...matches][0] : `title:${titleKey || "unknown-movie"}`;
+    keys.set(row, clusterKey);
+  }
+  return keys;
 }
 
 function rankStatsItems(map, limit = 10) {
@@ -981,9 +1039,39 @@ const updateWatchRowWatchedAtStmt = db.prepare("UPDATE watch_history SET watched
 function siblingWatchRowsFor(existing = {}) {
   if (!existing.id) return [];
   if (existing.media_type !== "episode") {
-    return existing.media_key
-      ? selectByMediaKeyStmt.all(existing.media_key).filter((row) => row.id !== existing.id && isPlembfinTrackedWatchRow(row))
-      : [];
+    const allMovies = selectMoviesStmt.all().filter(isPlembfinTrackedWatchRow);
+    const ids = [existing.imdb_id, existing.tmdb_id, existing.tvdb_id]
+      .map(cleanString)
+      .filter(Boolean);
+    const titleKey = canonicalTitleKey(existing.title);
+    const sameTitle = allMovies.filter((row) => canonicalTitleKey(row.title) === titleKey);
+    const parent = new Map();
+    const find = (key) => {
+      while (parent.get(key) !== key) {
+        parent.set(key, parent.get(parent.get(key)));
+        key = parent.get(key);
+      }
+      return key;
+    };
+    const union = (left, right) => {
+      if (left && right) parent.set(find(left), find(right));
+    };
+    for (const row of sameTitle) {
+      const rowIds = [row.imdb_id, row.tmdb_id, row.tvdb_id]
+        .map(cleanString)
+        .filter(Boolean);
+      rowIds.forEach((key) => { if (!parent.has(key)) parent.set(key, key); });
+      for (let index = 1; index < rowIds.length; index += 1) union(rowIds[0], rowIds[index]);
+    }
+    const providerClusters = new Set([...parent.keys()].map(find));
+    return allMovies.filter((row) => {
+      if (row.id === existing.id) return false;
+      const sharesProviderId = ids.some((id) => [row.imdb_id, row.tmdb_id, row.tvdb_id]
+        .map(cleanString)
+        .includes(id));
+      const isUnambiguousTitleMatch = titleKey && canonicalTitleKey(row.title) === titleKey && providerClusters.size === 1;
+      return sharesProviderId || isUnambiguousTitleMatch;
+    });
   }
 
   const showKey = canonicalTitleKey(existing.show_title || showTitleFrom(existing.title));
@@ -1647,6 +1735,7 @@ export async function getWatchStats() {
   if (statsCache.version === version && statsCache.stats) return statsCache.stats;
 
   const rows = (await loadHistoryRows({ limit: MAX_HISTORY_LIMIT, offset: 0 })).filter(isPlembfinTrackedWatchRow);
+  const statsMovieKeys = buildStatsMovieKeys(rows);
   const movieKeys = new Set();
   let episodes = 0;
   const bySource = new Map();
@@ -1656,7 +1745,10 @@ export async function getWatchStats() {
   const statsMonthPeriods = new Map();
   const allPeriod = createStatsPeriod("all", "All time");
 
-  for (const row of rows) {
+  for (const sourceRow of rows) {
+    const row = sourceRow.media_type === "movie"
+      ? { ...sourceRow, _statsMovieKey: statsMovieKeys.get(sourceRow) }
+      : sourceRow;
     const source = normalizePlatformSource(row.source);
     bySource.set(source, (bySource.get(source) || 0) + 1);
     const month = String(row.watched_at || "").slice(0, 7) || "unknown";

--- a/test/dataRepoCaches.test.js
+++ b/test/dataRepoCaches.test.js
@@ -144,3 +144,38 @@ test("show rematch stamps every episode in one operation and clears stale artwor
     assert.equal(row.backdrop_url, null);
   }
 });
+
+test("stats merge title-only movie plays into one provider identity", async () => {
+  const firstPlayId = await insert({
+    title: "Merged Identity Movie",
+    media_type: "movie",
+    watched_at: "2026-02-01T12:00:00.000Z",
+    source: "plex",
+    tmdb_id: "merged-tmdb",
+  });
+  await insert({
+    title: "Merged Identity Movie",
+    media_type: "movie",
+    watched_at: "2026-02-02T12:00:00.000Z",
+    source: "plex",
+    tmdb_id: "merged-tmdb",
+  });
+  await insert({
+    title: "Merged Identity Movie",
+    media_type: "movie",
+    watched_at: "2026-02-03T12:00:00.000Z",
+    source: "plex_initial_sync",
+  });
+
+  const stats = await repo.getWatchStats();
+  const matches = stats.reports.all.topMovies.filter((movie) => movie.title === "Merged Identity Movie");
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].count, 3);
+
+  const movies = await repo.queryMovies({ search: "Merged Identity Movie" });
+  assert.equal(movies.length, 1);
+  assert.equal(movies[0].playHistory.length, 3);
+
+  const dateEditorRows = await repo.getWatchDatesForRecord(firstPlayId);
+  assert.equal(dateEditorRows.rows.length, 3);
+});


### PR DESCRIPTION
## What changed

- Bump Plembfin from 0.5.37 to 0.6.0.
- Use canonical movie slugs for stats links.
- Merge provider-ID and title-only movie plays into one movie identity across stats and detail pages.
- Show the complete watch history in the Edit Watch Date dialog, retaining individual row IDs for editing and deletion.

## Why

Movie plays imported from different sources could be split between provider-keyed and title-only records. Stats, movie detail pages, and the edit-date dialog therefore showed inconsistent counts.

## Validation

- `npm test -- test/dataRepoCaches.test.js`
- `npm run build` (110 tests passed)
