### PR TITLE
fix: resolve code scanning alerts

### DIFF
--- a/server/src/utils/diagnosticLogger.js
+++ b/server/src/utils/diagnosticLogger.js
@@ -127,7 +127,10 @@ function scheduleFlush() {
 function addLog(level, args) {
   if (!isCapturing) return;
   const message = args.map((arg) => {
-    if (arg instanceof Error) return redactSecrets(arg.stack || arg.message || String(arg));
+    // Diagnostic logs are exposed through the admin logs endpoint. Keep the
+    // error message for troubleshooting, but never persist a stack trace that
+    // could disclose server-side paths or implementation details to a client.
+    if (arg instanceof Error) return redactSecrets(arg.message || String(arg));
     if (typeof arg === "object") return redactSecrets(util.inspect(arg, { depth: 6, breakLength: 120, compact: false }));
     return redactSecrets(arg);
   }).join(" ");

--- a/server/src/utils/embyClient.js
+++ b/server/src/utils/embyClient.js
@@ -298,7 +298,7 @@ async function findByProviderIds(config, media, itemTypes) {
   const settled = await Promise.allSettled(lookups);
   settled.forEach((result, index) => {
     if (result.status === "rejected") {
-      console.error(`Emby lookup failed for providerTerm: ${terms[index]}`, result.reason);
+      console.error("Emby lookup failed for providerTerm: %s", terms[index], result.reason);
       return;
     }
     for (const item of result.value.items) {

--- a/server/src/utils/jellyfinClient.js
+++ b/server/src/utils/jellyfinClient.js
@@ -286,7 +286,7 @@ async function findByProviderIds(config, media, itemTypes) {
   const settled = await Promise.allSettled(lookups);
   settled.forEach((result, index) => {
     if (result.status === "rejected") {
-      console.error(`Jellyfin lookup failed for providerTerm: ${terms[index]}`, result.reason);
+      console.error("Jellyfin lookup failed for providerTerm: %s", terms[index], result.reason);
       return;
     }
     for (const item of result.value.items) {

--- a/server/src/utils/plexWatchlistClient.js
+++ b/server/src/utils/plexWatchlistClient.js
@@ -210,11 +210,11 @@ export async function fetchPlexWatchlistSnapshot(config, options = {}) {
 
 function xmlEntity(value) {
   return String(value || "")
-    .replace(/&amp;/g, "&")
     .replace(/&quot;/g, '"')
     .replace(/&apos;/g, "'")
     .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">");
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
 }
 
 function parsePlexRss(text) {

--- a/server/src/utils/tvdbGateway.js
+++ b/server/src/utils/tvdbGateway.js
@@ -58,8 +58,9 @@ function canonicalTitle(value = "") {
 }
 
 function titleParts(value = "") {
-  const text = String(value || "").trim().replace(/\s*\(\d{4}\)\s*$/, "");
-  const yearMatch = String(value || "").trim().match(/\((\d{4})\)\s*$/);
+  const trimmed = String(value || "").trim();
+  const yearMatch = trimmed.match(/\((\d{4})\)$/);
+  const text = yearMatch ? trimmed.slice(0, yearMatch.index).trim() : trimmed;
   return { title: text, year: yearMatch?.[1] || "" };
 }
 

--- a/test/diagnosticLogger.test.js
+++ b/test/diagnosticLogger.test.js
@@ -22,3 +22,13 @@ test("diagnostic logs classify messages into categories correctly", () => {
   assert.equal(logger.categorizeLog("syncRecentlyWatchedFromPlex starting"), "scheduled-poll");
   assert.equal(logger.categorizeLog("Random server startup event"), "system");
 });
+
+test("diagnostic logs keep error messages without exposing stack traces", () => {
+  const marker = "diagnostic-stack-redaction-test";
+  console.error(new Error(marker));
+  const result = logger.getLogs({ level: "error", limit: 20 });
+  const line = result.logs.find((entry) => entry.includes(marker));
+
+  assert.ok(line);
+  assert.equal(line.includes("at diagnosticLogger.test.js"), false);
+});

--- a/test/plexWatchlistSecurity.test.js
+++ b/test/plexWatchlistSecurity.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "plembfin-plex-rss-test-"));
+
+const { fetchPlexWatchlistRss } = await import("../server/src/utils/plexWatchlistClient.js");
+
+test("Plex RSS decoding does not double-unescape encoded entities", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    text: async () => "<rss><channel><item><title>&amp;quot;Encoded&amp;quot;</title><guid>tmdb://123</guid><mediaType>movie</mediaType></item></channel></rss>",
+  });
+
+  try {
+    const result = await fetchPlexWatchlistRss({ rssUrl: "https://plex.example.test/watchlist.xml", token: "test-token" });
+    assert.equal(result.items[0]?.remote_item?.title, "&quot;Encoded&quot;");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/test/tvdbMatching.test.js
+++ b/test/tvdbMatching.test.js
@@ -7,7 +7,7 @@ import path from "node:path";
 const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "plembfin-tvdb-match-test-"));
 process.env.DATA_DIR = dataDir;
 
-const { selectTvdbSeriesMatch, tvdbSeriesTitleMatches } = await import("../server/src/utils/tvdbGateway.js");
+const { selectTvdbSeriesMatch, tvdbSeriesTitleKey, tvdbSeriesTitleMatches } = await import("../server/src/utils/tvdbGateway.js");
 
 test("TVDB title matching ignores ranked distractors but requires an exact unique series", () => {
   const result = selectTvdbSeriesMatch([
@@ -32,6 +32,10 @@ test("TVDB title matching can disambiguate a year-qualified title", () => {
   ], "The Office (2020)");
 
   assert.equal(result?.tvdb_id, "456");
+});
+
+test("TVDB title keys handle whitespace around a year suffix", () => {
+  assert.equal(tvdbSeriesTitleKey(`The Office${" ".repeat(1000)}(2020)`), "the office");
 });
 
 test("TVDB series verification accepts the canonical name and aliases only", () => {


### PR DESCRIPTION
## Summary
- keep Error.stack out of admin-visible diagnostic logs
- remove tainted format strings from Emby and Jellyfin lookup logging
- decode Plex RSS entities in the safe order
- replace the polynomial TVDB title-suffix regex with linear parsing
- add regression coverage for the security fixes

## Validation
- npm test (595 passing)
- npm run build