### PR TITLE
fix: remove remaining stack trace exposure

### DIFF
--- a/server/src/routes/watchlistSync.js
+++ b/server/src/routes/watchlistSync.js
@@ -2,7 +2,7 @@ import { requireAdmin } from "../utils/auth.js";
 import { readJson } from "../utils/requestBody.js";
 import { methodNotAllowed, sendJson, sendOptions } from "../utils/http.js";
 import { loadMediaConfig } from "../utils/configStore.js";
-import { listWatchlistActivity, redactWatchlistError } from "../utils/personalWatchlistRepository.js";
+import { listWatchlistActivity } from "../utils/personalWatchlistRepository.js";
 import { getWatchlistSyncStatus, previewWatchlistSync, runWatchlistSync } from "../utils/personalWatchlistSync.js";
 
 function clean(value) { return String(value ?? "").trim().toLowerCase(); }
@@ -40,6 +40,8 @@ export async function handleWatchlistSync(req, res) {
     const confirm = body.confirm === true || body.confirmed === true || body.confirmPublish === true;
     return sendJson(res, await runWatchlistSync({ mode, confirm, providers, config }));
   } catch (error) {
-    return sendJson(res, { error: redactWatchlistError(error) }, Number(error.status) || 500);
+    const status = Number(error?.status);
+    const responseStatus = Number.isInteger(status) && status >= 400 && status < 500 ? status : 500;
+    return sendJson(res, { error: "Watchlist sync failed" }, responseStatus);
   }
 }

--- a/server/src/utils/credentialVault.js
+++ b/server/src/utils/credentialVault.js
@@ -29,22 +29,25 @@ export function loadCredentialKey({ keyPath = CREDENTIAL_KEY_PATH, database = db
   const environmentKey = decodeEnvironmentKey(env.PLEMBFIN_CREDENTIAL_KEY);
   if (environmentKey) return environmentKey;
 
+  let key = null;
   try {
-    const key = fs.readFileSync(keyPath);
-    if (key.length !== KEY_BYTES) throw new Error(`Credential key at ${keyPath} is invalid; expected exactly 32 bytes`);
+    key = fs.readFileSync(keyPath);
+  } catch {
+    if (fs.existsSync(keyPath)) throw new Error("Credential key could not be read");
+  }
+  if (key) {
+    if (key.length !== KEY_BYTES) throw new Error("Credential key is invalid; expected exactly 32 bytes");
     return key;
-  } catch (error) {
-    if (error?.code !== "ENOENT") throw error;
   }
 
   if (encryptedCredentialsExist(database)) {
     throw new Error("Credential key is missing while encrypted media credentials exist; restore credential.key or set PLEMBFIN_CREDENTIAL_KEY");
   }
 
-  const key = crypto.randomBytes(KEY_BYTES);
-  fs.writeFileSync(keyPath, key, { mode: 0o600, flag: "wx" });
+  const generatedKey = crypto.randomBytes(KEY_BYTES);
+  fs.writeFileSync(keyPath, generatedKey, { mode: 0o600, flag: "wx" });
   try { fs.chmodSync(keyPath, 0o600); } catch { /* non-POSIX filesystem */ }
-  return key;
+  return generatedKey;
 }
 
 export function encryptCredential(value, options = {}) {

--- a/server/src/utils/outbound.js
+++ b/server/src/utils/outbound.js
@@ -3,6 +3,30 @@ import { acquireOutboundSlot, noteOutboundResponse, configureOutboundGovernor } 
 
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
 const MAX_OUTBOUND_REDIRECTS = 5;
+const OUTBOUND_POLICY_CODES = Object.freeze({
+  INVALID_URL: "OUTBOUND_INVALID_URL",
+  UNSUPPORTED_SCHEME: "OUTBOUND_UNSUPPORTED_SCHEME",
+  CREDENTIALS: "OUTBOUND_CREDENTIALS",
+  METADATA: "OUTBOUND_METADATA",
+  REDIRECT_LIMIT: "OUTBOUND_REDIRECT_LIMIT",
+});
+
+function outboundPolicyError(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function publicOutboundPolicyError(code) {
+  const messages = {
+    [OUTBOUND_POLICY_CODES.INVALID_URL]: "Outbound URL must be valid",
+    [OUTBOUND_POLICY_CODES.UNSUPPORTED_SCHEME]: "Outbound URL must use http or https",
+    [OUTBOUND_POLICY_CODES.CREDENTIALS]: "Outbound URL must not contain embedded credentials",
+    [OUTBOUND_POLICY_CODES.METADATA]: "Outbound URL targets a blocked metadata endpoint",
+    [OUTBOUND_POLICY_CODES.REDIRECT_LIMIT]: "Upstream request exceeded the redirect limit",
+  };
+  return messages[code] ? outboundPolicyError(messages[code], code) : null;
+}
 
 export function createUpstreamTimeoutError(timeoutMs = DEFAULT_FETCH_TIMEOUT_MS) {
   const error = new Error(`Upstream request timed out after ${timeoutMs}ms`);
@@ -49,17 +73,17 @@ export function assertSafeOutboundUrl(value, { label = "URL" } = {}) {
   try {
     url = new URL(String(value));
   } catch {
-    throw new Error(`${label} must be a valid URL`);
+    throw outboundPolicyError(`${label} must be a valid URL`, OUTBOUND_POLICY_CODES.INVALID_URL);
   }
   if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new Error(`${label} must use http or https`);
+    throw outboundPolicyError(`${label} must use http or https`, OUTBOUND_POLICY_CODES.UNSUPPORTED_SCHEME);
   }
   if (url.username || url.password) {
-    throw new Error(`${label} must not contain embedded credentials`);
+    throw outboundPolicyError(`${label} must not contain embedded credentials`, OUTBOUND_POLICY_CODES.CREDENTIALS);
   }
   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (BLOCKED_HOSTS.has(host)) {
-    throw new Error(`${label} targets a blocked metadata endpoint`);
+    throw outboundPolicyError(`${label} targets a blocked metadata endpoint`, OUTBOUND_POLICY_CODES.METADATA);
   }
   return url;
 }
@@ -97,7 +121,7 @@ async function fetchFollowingSafeRedirects(url, options) {
 
     const location = response.headers.get("location");
     if (!location) return response;
-    if (redirects === MAX_OUTBOUND_REDIRECTS) throw new Error("Upstream request exceeded the redirect limit");
+    if (redirects === MAX_OUTBOUND_REDIRECTS) throw outboundPolicyError("Upstream request exceeded the redirect limit", OUTBOUND_POLICY_CODES.REDIRECT_LIMIT);
 
     const nextUrl = assertSafeOutboundUrl(new URL(location, currentUrl), { label: "Outbound redirect URL" });
     await response.body?.cancel();
@@ -105,17 +129,7 @@ async function fetchFollowingSafeRedirects(url, options) {
     currentUrl = nextUrl;
   }
 
-  throw new Error("Upstream request exceeded the redirect limit");
-}
-
-function upstreamCauseCode(error) {
-  let current = error;
-  for (let depth = 0; depth < 5 && current; depth += 1) {
-    const code = String(current?.code || "").trim().toUpperCase();
-    if (/^[A-Z][A-Z0-9_:-]{1,48}$/.test(code)) return code;
-    current = current?.cause;
-  }
-  return "";
+  throw outboundPolicyError("Upstream request exceeded the redirect limit", OUTBOUND_POLICY_CODES.REDIRECT_LIMIT);
 }
 
 // Set PLEMBFIN_DEBUG_OUTBOUND=1 to log a per-host outbound request count once
@@ -173,14 +187,14 @@ export async function fetchWithTimeout(url, options = {}, timeoutMs = undefined)
     return response;
   } catch (error) {
     if (controller.signal.aborted && controller.signal.reason === timeoutError) throw timeoutError;
-    const message = String(error?.message || "").trim();
-    const causeCode = upstreamCauseCode(error);
-    if (causeCode && /^fetch failed$/i.test(message)) {
-      const wrapped = new Error(`Upstream request failed (${causeCode})`);
-      wrapped.code = causeCode;
-      throw wrapped;
+    const policyError = publicOutboundPolicyError(error?.code);
+    if (policyError) throw policyError;
+    if (controller.signal.aborted) {
+      const cancelled = new Error("Upstream request cancelled");
+      cancelled.name = "AbortError";
+      throw cancelled;
     }
-    throw error;
+    throw new Error("Upstream request failed");
   } finally {
     clearTimeout(timeout);
     if (upstreamSignal) upstreamSignal.removeEventListener("abort", abortFromUpstream);

--- a/server/src/utils/plexTokenManager.js
+++ b/server/src/utils/plexTokenManager.js
@@ -49,11 +49,10 @@ function claimRefreshLease(connectionId, owner, now) {
     WHERE id=? AND (refresh_lease_expires_at IS NULL OR refresh_lease_expires_at<=? OR refresh_lease_owner=?)`).run(owner, now + LEASE_MS, now, connectionId, now, owner).changes === 1;
 }
 
-function releaseFailedLease(row, owner, error, now) {
-  const rejected = [401, 403, 422].includes(Number(error?.status));
+function releaseFailedLease(row, owner, reauthRequired, now) {
   db.prepare(`UPDATE media_connections SET refresh_lease_owner=NULL,refresh_lease_expires_at=NULL,
     refresh_failure_count=refresh_failure_count+1,status=CASE WHEN ? THEN 'reauth_required' ELSE status END,updated_at=?
-    WHERE id=? AND refresh_lease_owner=?`).run(rejected ? 1 : 0, now, row.id, owner);
+    WHERE id=? AND refresh_lease_owner=?`).run(reauthRequired ? 1 : 0, now, row.id, owner);
 }
 
 function delay(ms) {
@@ -100,12 +99,16 @@ export async function getValidPlexToken({ force = false, fetchImpl, now = () => 
     if (updated.changes !== 1) throw new Error("Plex token refresh lease was lost before the credential could be saved");
     return refreshed.token;
   } catch (error) {
-    releaseFailedLease(row, owner, error, now());
+    const status = Number(error?.status);
+    const reauthRequired = [401, 403, 422].includes(status);
+    releaseFailedLease(row, owner, reauthRequired, now());
     const latest = activePlexRow();
-    if (!force && latest && Number(latest.access_token_expires_at || 0) > now() && ![401, 403, 422].includes(Number(error?.status))) {
+    if (!force && latest && Number(latest.access_token_expires_at || 0) > now() && !reauthRequired) {
       return decryptedToken(latest, vaultOptions);
     }
-    throw error;
+    const safeError = new Error("Plex token refresh failed");
+    if (reauthRequired) safeError.status = status;
+    throw safeError;
   }
 }
 

--- a/test/credentialVault.test.js
+++ b/test/credentialVault.test.js
@@ -37,6 +37,24 @@ test("credential key is created once and missing-key recovery fails safely", () 
   }
 });
 
+test("invalid credential keys do not expose their filesystem path", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "plembfin-vault-invalid-"));
+  const keyPath = path.join(directory, "credential.key");
+  const database = new Database(":memory:");
+  database.exec("CREATE TABLE media_connections (credential_ciphertext TEXT)");
+  fs.writeFileSync(keyPath, Buffer.alloc(8));
+  try {
+    assert.throws(() => loadCredentialKey({ keyPath, database, env: {} }), (error) => {
+      assert.match(error.message, /Credential key is invalid/);
+      assert.doesNotMatch(error.message, /credential\.key/);
+      return true;
+    });
+  } finally {
+    database.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("secret-bearing diagnostic fields are recursively redacted", () => {
   assert.deepEqual(redactSecrets({ user: "a", accessToken: "x", nested: { privateKey: "y", ok: true } }), { user: "a", accessToken: "[redacted]", nested: { privateKey: "[redacted]", ok: true } });
 });

--- a/test/outbound.test.js
+++ b/test/outbound.test.js
@@ -56,6 +56,25 @@ test("fetchWithTimeout validates redirects and does not forward credentials acro
   assert.equal(requests[1].headers.has("x-api-key"), false);
 });
 
+test("fetchWithTimeout replaces upstream exception objects with a safe error", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    const error = new Error("sensitive upstream stack marker");
+    error.stack = "Error: sensitive upstream stack marker\\n    at provider.internal/request.js:1:1";
+    throw error;
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  await assert.rejects(
+    fetchWithTimeout("https://media.example.test/image.jpg"),
+    (error) => {
+      assert.equal(error.message, "Upstream request failed");
+      assert.doesNotMatch(error.stack, /sensitive upstream stack marker/);
+      return true;
+    },
+  );
+});
+
 test("fetchWithTimeout falls back to the tunable default when no explicit timeout is given", async (t) => {
   t.after(() => resetTuningForTests());
   applyTuningConfig({ outboundTimeoutSec: 2 }); // clamp minimum, 2000ms


### PR DESCRIPTION
Normalize all remaining caught provider and infrastructure errors before they can reach API JSON responses. Watchlist failures now return a fixed public message; credential and outbound errors are rewrapped; Plex refresh errors no longer rethrow the original exception. Added regression coverage for credential-path and upstream-stack redaction. Tests: npm test (598 passing); npm run build.